### PR TITLE
Feat/verify signed data for issue endpoints

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -7,6 +7,10 @@
         {
           "name": "SENTRY_DSN",
           "valueFrom": "tis-trainee-credentials-sentry-dsn"
+        },
+        {
+          "name": "SIGNATURE_SECRET_KEY",
+          "valueFrom": "/tis/trainee/${environment}/signature/secret-key"
         }
       ],
       "logConfiguration": {

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.0.1"
+version = "0.1.0"
 
 configurations {
   compileOnly {

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ dependencies {
   ext.sentryVersion = "6.11.0"
   implementation "io.sentry:sentry-spring-boot-starter:$sentryVersion"
   implementation "io.sentry:sentry-logback:$sentryVersion"
+
+  implementation "commons-codec:commons-codec:1.15"
 }
 
 checkstyle {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/TisTraineeCredentialsApplication.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/TisTraineeCredentialsApplication.java
@@ -24,6 +24,9 @@ package uk.nhs.hee.tis.trainee.credentials;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+/**
+ * An application for issuing and verifying trainee digital credentials.
+ */
 @SpringBootApplication
 public class TisTraineeCredentialsApplication {
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResource.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.nhs.hee.tis.trainee.credentials.dto.Placement;
+import uk.nhs.hee.tis.trainee.credentials.dto.Programme;
+
+@RestController()
+@RequestMapping("/api/issue")
+public class IssueResource {
+
+  @PostMapping("/placement")
+  ResponseEntity<String> issuePlacement(@RequestBody Placement placement) {
+    return ResponseEntity.ok(
+        "Issuing Placement %s (%s)".formatted(placement.getId(), placement.getName()));
+  }
+
+  @PostMapping("/programme")
+  ResponseEntity<String> issueProgramme(@RequestBody Programme programme) {
+    return ResponseEntity.ok(
+        "Issuing Programme %s (%s)".formatted(programme.getId(), programme.getName()));
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResource.java
@@ -21,27 +21,28 @@
 
 package uk.nhs.hee.tis.trainee.credentials.api;
 
+import java.time.LocalDate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import uk.nhs.hee.tis.trainee.credentials.dto.Placement;
-import uk.nhs.hee.tis.trainee.credentials.dto.Programme;
 
+/**
+ * API endpoints for issuing trainee digital credentials.
+ */
 @RestController()
 @RequestMapping("/api/issue")
 public class IssueResource {
 
-  @PostMapping("/placement")
-  ResponseEntity<String> issuePlacement(@RequestBody Placement placement) {
+  @PostMapping("/test")
+  ResponseEntity<String> issueTestCredential(@RequestBody TestCredential testCredential) {
     return ResponseEntity.ok(
-        "Issuing Placement %s (%s)".formatted(placement.getId(), placement.getName()));
+        "Issuing Test Credential for %s %s".formatted(testCredential.givenName(),
+            testCredential.familyName));
   }
 
-  @PostMapping("/programme")
-  ResponseEntity<String> issueProgramme(@RequestBody Programme programme) {
-    return ResponseEntity.ok(
-        "Issuing Programme %s (%s)".formatted(programme.getId(), programme.getName()));
+  private record TestCredential(String givenName, String familyName, LocalDate birthDate) {
+
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/filter/CachedBodyRequestWrapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/filter/CachedBodyRequestWrapper.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.filter;
+
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import org.springframework.util.StreamUtils;
+
+/**
+ * A request wrapper which uses a cached body
+ */
+public class CachedBodyHttpServletRequest extends HttpServletRequestWrapper {
+
+  private final byte[] cachedBody;
+
+  /**
+   * Constructs a request object wrapping the given request.
+   *
+   * @param request The request to wrap
+   * @throws IllegalArgumentException if the request is null
+   */
+  public CachedBodyHttpServletRequest(HttpServletRequest request) throws IOException {
+    super(request);
+    InputStream requestInputStream = request.getInputStream();
+    cachedBody = StreamUtils.copyToByteArray(requestInputStream);
+  }
+
+  @Override
+  public ServletInputStream getInputStream() {
+    return new CachedBodyServletInputStream(cachedBody);
+  }
+
+  @Override
+  public BufferedReader getReader() {
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(this.cachedBody);
+    return new BufferedReader(new InputStreamReader(inputStream));
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/filter/FilterConfiguration.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/filter/FilterConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.filter;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+@Configuration
+public class FilterConfiguration {
+
+  @Bean
+  public FilterRegistrationBean<SignedDataFilter> registerSignedDataFilter() {
+    var registrationBean = new FilterRegistrationBean<SignedDataFilter>();
+
+    registrationBean.setFilter(new SignedDataFilter());
+    registrationBean.addUrlPatterns("/api/issue/*");
+    registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE);
+
+    return registrationBean;
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/filter/FilterConfiguration.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/filter/FilterConfiguration.java
@@ -26,14 +26,24 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 
+/**
+ * A configuration for request filters.
+ */
 @Configuration
 public class FilterConfiguration {
 
+  /**
+   * Register a {@link SignedDataFilter}.
+   *
+   * @param filter The filter to register.
+   * @return The {@link FilterRegistrationBean} for the registration.
+   */
   @Bean
-  public FilterRegistrationBean<SignedDataFilter> registerSignedDataFilter() {
-    var registrationBean = new FilterRegistrationBean<SignedDataFilter>();
+  public FilterRegistrationBean<SignedDataFilter> registerSignedDataFilter(
+      SignedDataFilter filter) {
+    FilterRegistrationBean<SignedDataFilter> registrationBean = new FilterRegistrationBean<>();
 
-    registrationBean.setFilter(new SignedDataFilter());
+    registrationBean.setFilter(filter);
     registrationBean.addUrlPatterns("/api/issue/*");
     registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE);
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/filter/SignedDataFilter.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/filter/SignedDataFilter.java
@@ -1,0 +1,77 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.Period;
+import org.apache.commons.codec.digest.HmacAlgorithms;
+import org.apache.commons.codec.digest.HmacUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class SignedDataFilter extends OncePerRequestFilter {
+
+  private static final String SIGNATURE_FIELD = "signature";
+  private static final String SIGNATURE_TIMESTAMP_FIELD = "signatureTimestamp";
+  private static final String SIGNATURE_SECRET_KEY = "do-not-actually-use-this";
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    CachedBodyHttpServletRequest cachedBodyHttpServletRequest = new CachedBodyHttpServletRequest(
+        request);
+
+    if (hasValidSignature(cachedBodyHttpServletRequest)) {
+      filterChain.doFilter(cachedBodyHttpServletRequest, response);
+    } else {
+      response.setStatus(403);
+    }
+  }
+
+  private boolean hasValidSignature(CachedBodyHttpServletRequest request) throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    ObjectNode tree = (ObjectNode) mapper.readTree(request.getInputStream());
+
+    String signature = tree.remove(SIGNATURE_FIELD).asText();
+    LocalDate signatureTimestamp = LocalDate.parse(tree.get(SIGNATURE_TIMESTAMP_FIELD).asText());
+
+    if (signature != null && signatureTimestamp != null) {
+
+      if (!signatureTimestamp.isBefore(LocalDate.now().minus(Period.ofDays(1)))) {
+        // Signature not expired.
+
+        byte[] treeBytes = mapper.writeValueAsBytes(tree);
+        String verificationSignature = new HmacUtils(HmacAlgorithms.HMAC_SHA_256,
+            SIGNATURE_SECRET_KEY).hmacHex(treeBytes);
+        return signature.equals(verificationSignature);
+      }
+    }
+
+    return false;
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/filter/SignedDataFilter.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/filter/SignedDataFilter.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.tis.trainee.credentials.filter;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.servlet.FilterChain;
@@ -28,50 +29,97 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.time.LocalDate;
-import java.time.Period;
+import java.time.Instant;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.HmacAlgorithms;
 import org.apache.commons.codec.digest.HmacUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+/**
+ * A request filter that verifies the signature of signed data.
+ */
+@Slf4j
+@Component
 public class SignedDataFilter extends OncePerRequestFilter {
 
   private static final String SIGNATURE_FIELD = "signature";
-  private static final String SIGNATURE_TIMESTAMP_FIELD = "signatureTimestamp";
-  private static final String SIGNATURE_SECRET_KEY = "do-not-actually-use-this";
+  private static final String HMAC_FIELD = "hmac";
+
+  private final ObjectMapper mapper;
+  private final String signatureSecretKey;
+
+  /**
+   * Create a request filter that verifies the signature of signed data.
+   *
+   * @param mapper             An {@link ObjectMapper} to use when reading the request payload.
+   * @param signatureSecretKey The secret key used to sign and verify the signature.
+   */
+  SignedDataFilter(ObjectMapper mapper,
+      @Value("${application.signature.secret-key}") String signatureSecretKey) {
+    this.mapper = mapper;
+    this.signatureSecretKey = signatureSecretKey;
+  }
 
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
       FilterChain filterChain) throws ServletException, IOException {
-    CachedBodyHttpServletRequest cachedBodyHttpServletRequest = new CachedBodyHttpServletRequest(
-        request);
+    request = new CachedBodyRequestWrapper(request);
 
-    if (hasValidSignature(cachedBodyHttpServletRequest)) {
-      filterChain.doFilter(cachedBodyHttpServletRequest, response);
-    } else {
+    try {
+      if (hasValidSignature(request)) {
+        filterChain.doFilter(request, response);
+      } else {
+        response.setStatus(403);
+      }
+    } catch (IOException e) {
+      log.error("Unable to validate data signature.", e);
       response.setStatus(403);
     }
   }
 
-  private boolean hasValidSignature(CachedBodyHttpServletRequest request) throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
-    ObjectNode tree = (ObjectNode) mapper.readTree(request.getInputStream());
+  /**
+   * Validate whether the given request has a payload with a valid signature.
+   *
+   * @param request The request to validate.
+   * @return Whether the request was signed and valid.
+   * @throws IOException If the request could not be parsed to signed data.
+   */
+  private boolean hasValidSignature(HttpServletRequest request) throws IOException {
+    JsonNode tree = mapper.readTree(request.getInputStream());
+    JsonNode signatureNode = tree.get(SIGNATURE_FIELD);
 
-    String signature = tree.remove(SIGNATURE_FIELD).asText();
-    LocalDate signatureTimestamp = LocalDate.parse(tree.get(SIGNATURE_TIMESTAMP_FIELD).asText());
+    if (signatureNode != null) {
+      record Signature(String hmac, Instant signedAt, Instant validUntil) {}
 
-    if (signature != null && signatureTimestamp != null) {
+      Signature signature = mapper.treeToValue(signatureNode, Signature.class);
 
-      if (!signatureTimestamp.isBefore(LocalDate.now().minus(Period.ofDays(1)))) {
-        // Signature not expired.
+      String hmac = signature.hmac();
+      Instant signedAt = signature.signedAt();
+      Instant validUntil = signature.validUntil();
 
+      if (hmac != null && isValidInstant(signedAt, true) && isValidInstant(validUntil, false)) {
+        ((ObjectNode) signatureNode).remove(HMAC_FIELD);
         byte[] treeBytes = mapper.writeValueAsBytes(tree);
         String verificationSignature = new HmacUtils(HmacAlgorithms.HMAC_SHA_256,
-            SIGNATURE_SECRET_KEY).hmacHex(treeBytes);
-        return signature.equals(verificationSignature);
+            signatureSecretKey).hmacHex(treeBytes);
+        return hmac.equals(verificationSignature);
       }
     }
 
     return false;
+  }
+
+  /**
+   * Validate the provided {@link Instant} against the current Instant.
+   *
+   * @param instant     The Instant to validate.
+   * @param requirePast Whether the Instant must be in the past, else it must be in the future.
+   * @return Whether the Instant is valid.
+   */
+  private boolean isValidInstant(Instant instant, boolean requirePast) {
+    Instant now = Instant.now();
+    return instant != null && instant.compareTo(now) > 0 != requirePast;
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,10 @@ server:
   servlet:
     context-path: /credentials
 
+application:
+  signature:
+    secret-key: ${SIGNATURE_SECRET_KEY}
+
 sentry:
   dsn: ${SENTRY_DSN:}
   environment: ${SENTRY_ENVIRONMENT:}

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/SignatureTestUtil.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/SignatureTestUtil.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.apache.commons.codec.digest.HmacAlgorithms;
+import org.apache.commons.codec.digest.HmacUtils;
+
+/**
+ * A test utility with helper methods for data signatures.
+ */
+public class SignatureTestUtil {
+
+  private static final String SIGNATURE_FIELD = "signature";
+  private static final String HMAC_FIELD = "hmac";
+
+  private static final ObjectMapper MAPPER;
+
+  static {
+    MAPPER = new ObjectMapper();
+    MAPPER.registerModule(new JavaTimeModule());
+  }
+
+  /**
+   * A helper method to sign test data with a valid HMAC.
+   *
+   * @param dataToSign The data to sign.
+   * @param secretKey  The secret key to sign the data with.
+   * @return A string representation of the signed data.
+   * @throws JsonProcessingException If the dataToSign was not valid JSON.
+   */
+  public static String signData(String dataToSign, String secretKey)
+      throws JsonProcessingException {
+    JsonNode nodeToSign = MAPPER.readTree(dataToSign);
+    ObjectNode signatureNode = (ObjectNode) nodeToSign.get(SIGNATURE_FIELD);
+
+    byte[] bytesToSign = MAPPER.writeValueAsBytes(nodeToSign);
+    String hmac = new HmacUtils(HmacAlgorithms.HMAC_SHA_256, secretKey).hmacHex(
+        bytesToSign);
+    signatureNode.put(HMAC_FIELD, hmac);
+
+    return nodeToSign.toString();
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResourceTest.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.nhs.hee.tis.trainee.credentials.SignatureTestUtil;
+
+@WebMvcTest(IssueResource.class)
+class IssueResourceTest {
+
+  public static final String UNSIGNED_DATA = """
+      {
+            "givenName": "Anthony",
+            "familyName": "Gilliam",
+            "birthDate": "1991-11-11",
+            "signature": {
+              "signedAt": "%s",
+              "validUntil": "%s"
+            }
+          }
+      """.formatted(Instant.MIN, Instant.MAX);
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Value("${application.signature.secret-key}")
+  private String secretKey;
+
+  @Test
+  void shouldForbidUnsignedRequests() throws Exception {
+    mockMvc.perform(
+            post("/api/issue/test")
+                .content(UNSIGNED_DATA)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void shouldAllowSignedRequests() throws Exception {
+    String signedData = SignatureTestUtil.signData(UNSIGNED_DATA, secretKey);
+
+    mockMvc.perform(
+            post("/api/issue/test")
+                .content(signedData)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/filter/CachedBodyRequestWrapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/filter/CachedBodyRequestWrapperTest.java
@@ -1,0 +1,81 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.filter;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jakarta.servlet.ServletInputStream;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class CachedBodyRequestWrapperTest {
+
+  private static final String REQUEST_STRING = "request content";
+  private static final byte[] REQUEST_BYTES = REQUEST_STRING.getBytes(StandardCharsets.UTF_8);
+
+  private CachedBodyRequestWrapper requestWrapper;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setContent(REQUEST_BYTES);
+
+    requestWrapper = new CachedBodyRequestWrapper(request);
+  }
+
+  @Test
+  void shouldGetInputStreamsWithCachedBody() throws IOException {
+    ServletInputStream inputStream1 = requestWrapper.getInputStream();
+    assertThat("Unexpected stream ready status.", inputStream1.isReady(), is(true));
+    assertThat("Unexpected stream finished status.", inputStream1.isFinished(), is(false));
+    assertThat("Unexpected stream contents.", inputStream1.readAllBytes(), is(REQUEST_BYTES));
+
+
+    ServletInputStream inputStream2 = requestWrapper.getInputStream();
+    assertThat("Unexpected stream ready status.", inputStream2.isReady(), is(true));
+    assertThat("Unexpected stream finished status.", inputStream2.isFinished(), is(false));
+    assertThat("Unexpected stream contents.", inputStream2.readAllBytes(), is(REQUEST_BYTES));
+  }
+
+  @Test
+  void shouldGetReadersWithCachedBody() throws IOException {
+    BufferedReader reader1 = requestWrapper.getReader();
+    assertThat("Unexpected ready status.", reader1.ready(), is(true));
+    assertThat("Unexpected request body.", reader1.readLine(), is(REQUEST_STRING));
+
+    BufferedReader reader2 = requestWrapper.getReader();
+    assertThat("Unexpected ready status.", reader2.ready(), is(true));
+    assertThat("Unexpected request body.", reader2.readLine(), is(REQUEST_STRING));
+  }
+
+  @Test
+  void shouldThrowExceptionWhenSettingReadListenerOnCachedInputStream() {
+    assertThrows(UnsupportedOperationException.class,
+        () -> requestWrapper.getInputStream().setReadListener(null));
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/filter/CachedBodyRequestWrapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/filter/CachedBodyRequestWrapperTest.java
@@ -54,12 +54,13 @@ class CachedBodyRequestWrapperTest {
     assertThat("Unexpected stream ready status.", inputStream1.isReady(), is(true));
     assertThat("Unexpected stream finished status.", inputStream1.isFinished(), is(false));
     assertThat("Unexpected stream contents.", inputStream1.readAllBytes(), is(REQUEST_BYTES));
-
+    assertThat("Unexpected stream finished status.", inputStream1.isFinished(), is(true));
 
     ServletInputStream inputStream2 = requestWrapper.getInputStream();
     assertThat("Unexpected stream ready status.", inputStream2.isReady(), is(true));
     assertThat("Unexpected stream finished status.", inputStream2.isFinished(), is(false));
     assertThat("Unexpected stream contents.", inputStream2.readAllBytes(), is(REQUEST_BYTES));
+    assertThat("Unexpected stream finished status.", inputStream2.isFinished(), is(true));
   }
 
   @Test
@@ -75,7 +76,8 @@ class CachedBodyRequestWrapperTest {
 
   @Test
   void shouldThrowExceptionWhenSettingReadListenerOnCachedInputStream() {
-    assertThrows(UnsupportedOperationException.class,
-        () -> requestWrapper.getInputStream().setReadListener(null));
+    ServletInputStream inputStream = requestWrapper.getInputStream();
+
+    assertThrows(UnsupportedOperationException.class, () -> inputStream.setReadListener(null));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/filter/FilterConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/filter/FilterConfigurationTest.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.filter;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.Ordered;
+
+class FilterConfigurationTest {
+
+  private static final String SIGNATURE_SECRET_KEY = "test-secret-key";
+
+  FilterConfiguration configuration;
+
+  @BeforeEach
+  void setUp() {
+    configuration = new FilterConfiguration();
+  }
+
+  @Test
+  void shouldRegisterSignedDataFilter() {
+    SignedDataFilter filter = new SignedDataFilter(new ObjectMapper(), SIGNATURE_SECRET_KEY);
+
+    var registrationBean = configuration.registerSignedDataFilter(filter);
+
+    SignedDataFilter registeredFilter = registrationBean.getFilter();
+    assertThat("Unexpected registered filter.", registeredFilter, sameInstance(filter));
+  }
+
+  @Test
+  void shouldRegisterSignedDataFilterWithHighestPrecedence() {
+    SignedDataFilter filter = new SignedDataFilter(new ObjectMapper(), SIGNATURE_SECRET_KEY);
+
+    var registrationBean = configuration.registerSignedDataFilter(filter);
+
+    int order = registrationBean.getOrder();
+    assertThat("Unexpected filter precedence.", order, is(Ordered.HIGHEST_PRECEDENCE));
+  }
+
+  @Test
+  void shouldRegisterSignedDataFilterOnIssueApiEndpoints() {
+    SignedDataFilter filter = new SignedDataFilter(new ObjectMapper(), SIGNATURE_SECRET_KEY);
+
+    var registrationBean = configuration.registerSignedDataFilter(filter);
+
+    Collection<String> urlPatterns = registrationBean.getUrlPatterns();
+    assertThat("Unexpected filter pattern count.", urlPatterns.size(), is(1));
+    assertThat("Unexpected filter patterns.", urlPatterns, hasItem("/api/issue/*"));
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/filter/SignedDataFilterTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/filter/SignedDataFilterTest.java
@@ -1,0 +1,306 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.filter;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import uk.nhs.hee.tis.trainee.credentials.SignatureTestUtil;
+
+class SignedDataFilterTest {
+
+  private static final Instant SIGNED_AT = Instant.now().minus(Duration.ofDays(1));
+  private static final Instant VALID_UNTIL = Instant.now().plus(Duration.ofDays(1));
+
+  private static final String SIGNATURE_SECRET_KEY = "do-not-actually-use-this";
+
+  private static final String SIGNED_DATA_TEMPLATE = """
+      {
+        "id": 123,
+        "signature": {
+          "signedAt": "%s",
+          "validUntil": "%s"
+        }
+      }
+      """;
+
+  private SignedDataFilter filter;
+
+  @BeforeEach
+  void setUp() {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new JavaTimeModule());
+
+    filter = new SignedDataFilter(mapper, SIGNATURE_SECRET_KEY);
+  }
+
+  @Test
+  void shouldBeForbiddenWhenNoDataInRequest() throws Exception {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain filterChain = mock(FilterChain.class);
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat("Unexpected response status.", response.getStatus(), is(403));
+    verifyNoInteractions(filterChain);
+  }
+
+  @Test
+  void shouldBeForbiddenWhenDataIsNotJson() throws Exception {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setContent("not JSON".getBytes(UTF_8));
+
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain filterChain = mock(FilterChain.class);
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat("Unexpected response status.", response.getStatus(), is(403));
+    verifyNoInteractions(filterChain);
+  }
+
+  @Test
+  void shouldBeForbiddenWhenDataIsNotSigned() throws Exception {
+    String unsignedData = """
+          {
+            "id": 123
+          }
+        """;
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setContent(unsignedData.getBytes(UTF_8));
+
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain filterChain = mock(FilterChain.class);
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat("Unexpected response status.", response.getStatus(), is(403));
+    verifyNoInteractions(filterChain);
+  }
+
+  @Test
+  void shouldBeForbiddenWhenSignatureHasNoHmac() throws Exception {
+    String signedData = """
+          {
+            "id": 123,
+            "signature": {
+              "signedAt": "%s",
+              "validUntil": "%s"
+            }
+          }
+        """.formatted(SIGNED_AT, VALID_UNTIL);
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setContent(signedData.getBytes(UTF_8));
+
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain filterChain = mock(FilterChain.class);
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat("Unexpected response status.", response.getStatus(), is(403));
+    verifyNoInteractions(filterChain);
+  }
+
+  @Test
+  void shouldBeForbiddenWhenSignatureHasNoSignedAt() throws Exception {
+    String signedData = SignatureTestUtil.signData("""
+          {
+            "id": 123,
+            "signature": {
+              "validUntil": "%s"
+            }
+          }
+        """.formatted(VALID_UNTIL), SIGNATURE_SECRET_KEY);
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setContent(signedData.getBytes(UTF_8));
+
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain filterChain = mock(FilterChain.class);
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat("Unexpected response status.", response.getStatus(), is(403));
+    verifyNoInteractions(filterChain);
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {"", "abc"})
+  void shouldBeForbiddenWhenSignatureHasInvalidSignedAt(String signedAt) throws Exception {
+    String signedData = SignatureTestUtil.signData(
+        SIGNED_DATA_TEMPLATE.formatted(signedAt, VALID_UNTIL), SIGNATURE_SECRET_KEY);
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setContent(signedData.getBytes(UTF_8));
+
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain filterChain = mock(FilterChain.class);
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat("Unexpected response status.", response.getStatus(), is(403));
+    verifyNoInteractions(filterChain);
+  }
+
+  @Test
+  void shouldBeForbiddenWhenSignatureHasSignedAtInTheFuture() throws Exception {
+    String signedData = SignatureTestUtil.signData(
+        SIGNED_DATA_TEMPLATE.formatted(Instant.MAX, VALID_UNTIL), SIGNATURE_SECRET_KEY);
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setContent(signedData.getBytes(UTF_8));
+
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain filterChain = mock(FilterChain.class);
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat("Unexpected response status.", response.getStatus(), is(403));
+    verifyNoInteractions(filterChain);
+  }
+
+  @Test
+  void shouldBeForbiddenWhenSignatureHasNoValidUntil() throws Exception {
+    String signedData = SignatureTestUtil.signData("""
+          {
+            "id": 123,
+            "signature": {
+              "signedAt": "%s"
+            }
+          }
+        """.formatted(SIGNED_AT), SIGNATURE_SECRET_KEY);
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setContent(signedData.getBytes(UTF_8));
+
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain filterChain = mock(FilterChain.class);
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat("Unexpected response status.", response.getStatus(), is(403));
+    verifyNoInteractions(filterChain);
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {"", "abc"})
+  void shouldBeForbiddenWhenSignatureHasInvalidValidUntil(String validUntil) throws Exception {
+    String signedData = SignatureTestUtil.signData(
+        SIGNED_DATA_TEMPLATE.formatted(SIGNED_AT, validUntil), SIGNATURE_SECRET_KEY);
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setContent(signedData.getBytes(UTF_8));
+
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain filterChain = mock(FilterChain.class);
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat("Unexpected response status.", response.getStatus(), is(403));
+    verifyNoInteractions(filterChain);
+  }
+
+  @Test
+  void shouldBeForbiddenWhenSignatureHasValidUntilInThePast() throws Exception {
+    String signedData = SignatureTestUtil.signData(
+        SIGNED_DATA_TEMPLATE.formatted(SIGNED_AT, Instant.MIN), SIGNATURE_SECRET_KEY);
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setContent(signedData.getBytes(UTF_8));
+
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain filterChain = mock(FilterChain.class);
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat("Unexpected response status.", response.getStatus(), is(403));
+    verifyNoInteractions(filterChain);
+  }
+
+  @Test
+  void shouldCallFilterChainWhenSignatureVerifies() throws Exception {
+    String signedData = SignatureTestUtil.signData(
+        SIGNED_DATA_TEMPLATE.formatted(SIGNED_AT, VALID_UNTIL), SIGNATURE_SECRET_KEY);
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setContent(signedData.getBytes(UTF_8));
+
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain filterChain = mock(FilterChain.class);
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat("Unexpected response status.", response.getStatus(), is(200));
+    verify(filterChain).doFilter(any(HttpServletRequest.class), eq(response));
+  }
+
+  @Test
+  void shouldWrapTheRequestInputStreamForDownstreamConsumers() throws Exception {
+    String signedData = SignatureTestUtil.signData(
+        SIGNED_DATA_TEMPLATE.formatted(SIGNED_AT, VALID_UNTIL), SIGNATURE_SECRET_KEY);
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setContent(signedData.getBytes(UTF_8));
+
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain filterChain = mock(FilterChain.class);
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    ArgumentCaptor<HttpServletRequest> requestCaptor = ArgumentCaptor.forClass(
+        HttpServletRequest.class);
+    verify(filterChain).doFilter(requestCaptor.capture(), any());
+
+    ServletInputStream inputStream = requestCaptor.getValue().getInputStream();
+    assertThat("Unexpected stream ready status.", inputStream.isReady(), is(true));
+    assertThat("Unexpected stream finished status.", inputStream.isFinished(), is(false));
+    assertThat("Unexpected stream contents.", inputStream.readAllBytes(),
+        is(signedData.getBytes(UTF_8)));
+  }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+application:
+  signature:
+    secret-key: test-secret-key


### PR DESCRIPTION
Use the Spring security filter chain to verify that requests to issue credentials (via `/api/issue/*` endpoints) are providing signed data. See commit 423d39522227dbde61e5ea8b8e311a36aaad48df for full details about the approach.

TIS21-4067