### PR TITLE
Feat/issue programme membership credential

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ gradlew bootRun
 | GATEWAY_CLIENT_ID            | The client ID for the credential gateway.                 |           |
 | GATEWAY_CLIENT_SECRET        | The client secret for the credential gateway.             |           |
 | GATEWAY_TOKEN_ISSUER         | The issuer to add to the credential data.                 |           |
-| GATEWAY_TOKEN_SIGNING_KEY    | The signing key for the credential data.                  |           |
+| GATEWAY_TOKEN_SIGNING_KEY    | The Base64 encoded signing key for the credential data.   |           |
 | GATEWAY_ISSUING_REDIRECT_URI | Where the gateway issue should redirect to after issuing. |           |
 | SENTRY_DSN                   | A Sentry error monitoring Data Source Name.               |           |
 | SENTRY_ENVIRONMENT           | The environment to log Sentry events against.             | local     |

--- a/README.md
+++ b/README.md
@@ -15,10 +15,17 @@ gradlew bootRun
 
 #### Environmental Variables
 
-| Name               | Description                                     | Default   |
-|--------------------|-------------------------------------------------|-----------|
-| SENTRY_DSN         | A Sentry error monitoring Data Source Name.     |           |
-| SENTRY_ENVIRONMENT | The environment to log Sentry events against.   | local     |
+| Name                         | Description                                               | Default   |
+|------------------------------|-----------------------------------------------------------|-----------|
+| GATEWAY_HOST                 | The credential gateway host.                              |           |
+| GATEWAY_CLIENT_ID            | The client ID for the credential gateway.                 |           |
+| GATEWAY_CLIENT_SECRET        | The client secret for the credential gateway.             |           |
+| GATEWAY_TOKEN_ISSUER         | The issuer to add to the credential data.                 |           |
+| GATEWAY_TOKEN_SIGNING_KEY    | The signing key for the credential data.                  |           |
+| GATEWAY_ISSUING_REDIRECT_URI | Where the gateway issue should redirect to after issuing. |           |
+| SENTRY_DSN                   | A Sentry error monitoring Data Source Name.               |           |
+| SENTRY_ENVIRONMENT           | The environment to log Sentry events against.             | local     |
+| SIGNATURE_SECRET_KEY         | The secret key used to validate signed data.              |           |
 
 #### Usage Examples
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.1.0"
+version = "0.2.0"
 
 configurations {
   compileOnly {

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,11 @@ dependencies {
   implementation "io.sentry:sentry-logback:$sentryVersion"
 
   implementation "commons-codec:commons-codec:1.15"
+
+  ext.jjwtVersion = "0.11.5"
+  implementation "io.jsonwebtoken:jjwt-api:$jjwtVersion"
+  runtimeOnly "io.jsonwebtoken:jjwt-impl:$jjwtVersion"
+  runtimeOnly "io.jsonwebtoken:jjwt-jackson:$jjwtVersion"
 }
 
 checkstyle {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/TisTraineeCredentialsApplication.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/TisTraineeCredentialsApplication.java
@@ -38,4 +38,9 @@ public class TisTraineeCredentialsApplication {
   public static void main(String[] args) {
     SpringApplication.run(TisTraineeCredentialsApplication.class);
   }
+
+  @Bean
+  RestTemplate restTemplate(RestTemplateBuilder builder) {
+    return builder.build();
+  }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/TisTraineeCredentialsApplication.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/TisTraineeCredentialsApplication.java
@@ -23,11 +23,16 @@ package uk.nhs.hee.tis.trainee.credentials;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
 
 /**
  * An application for issuing and verifying trainee digital credentials.
  */
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class TisTraineeCredentialsApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResource.java
@@ -31,6 +31,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDataDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.ProgrammeMembershipDto;
 import uk.nhs.hee.tis.trainee.credentials.service.GatewayService;
 
 /**
@@ -46,6 +47,19 @@ public class IssueResource {
     this.service = service;
   }
 
+  @PostMapping("/programme-membership")
+  ResponseEntity<String> issueProgrammeMembershipCredential(@RequestBody ProgrammeMembershipDto dto,
+      @RequestParam(required = false) String state) {
+    Optional<URI> credentialUri = service.getCredentialUri(dto, state, "issue.ProgrammeMembership");
+
+    if (credentialUri.isPresent()) {
+      URI uri = credentialUri.get();
+      return ResponseEntity.created(uri).body(uri.toString());
+    } else {
+      return ResponseEntity.internalServerError().build();
+    }
+  }
+
   @PostMapping("/test")
   ResponseEntity<String> issueTestCredential(@RequestBody TestCredentialDto dto,
       @RequestParam(required = false) String state) {
@@ -59,7 +73,7 @@ public class IssueResource {
     }
   }
 
-  private record TestCredentialDto(String givenName, String familyName, LocalDate birthDate)
+  record TestCredentialDto(String givenName, String familyName, LocalDate birthDate)
       implements CredentialDataDto {
 
   }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResource.java
@@ -21,12 +21,17 @@
 
 package uk.nhs.hee.tis.trainee.credentials.api;
 
+import java.net.URI;
 import java.time.LocalDate;
+import java.util.Optional;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDataDto;
+import uk.nhs.hee.tis.trainee.credentials.service.GatewayService;
 
 /**
  * API endpoints for issuing trainee digital credentials.
@@ -35,14 +40,27 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/issue")
 public class IssueResource {
 
-  @PostMapping("/test")
-  ResponseEntity<String> issueTestCredential(@RequestBody TestCredential testCredential) {
-    return ResponseEntity.ok(
-        "Issuing Test Credential for %s %s".formatted(testCredential.givenName(),
-            testCredential.familyName));
+  private final GatewayService service;
+
+  IssueResource(GatewayService service) {
+    this.service = service;
   }
 
-  private record TestCredential(String givenName, String familyName, LocalDate birthDate) {
+  @PostMapping("/test")
+  ResponseEntity<String> issueTestCredential(@RequestBody TestCredentialDto dto,
+      @RequestParam(required = false) String state) {
+    Optional<URI> credentialUri = service.getCredentialUri(dto, state, "issue.TestCredential");
+
+    if (credentialUri.isPresent()) {
+      URI uri = credentialUri.get();
+      return ResponseEntity.created(uri).body(uri.toString());
+    } else {
+      return ResponseEntity.internalServerError().build();
+    }
+  }
+
+  private record TestCredentialDto(String givenName, String familyName, LocalDate birthDate)
+      implements CredentialDataDto {
 
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResource.java
@@ -22,7 +22,6 @@
 package uk.nhs.hee.tis.trainee.credentials.api;
 
 import java.net.URI;
-import java.time.LocalDate;
 import java.util.Optional;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,8 +29,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDataDto;
 import uk.nhs.hee.tis.trainee.credentials.dto.ProgrammeMembershipDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.TestCredentialDto;
 import uk.nhs.hee.tis.trainee.credentials.service.GatewayService;
 
 /**
@@ -50,7 +49,7 @@ public class IssueResource {
   @PostMapping("/programme-membership")
   ResponseEntity<String> issueProgrammeMembershipCredential(@RequestBody ProgrammeMembershipDto dto,
       @RequestParam(required = false) String state) {
-    Optional<URI> credentialUri = service.getCredentialUri(dto, state, "issue.ProgrammeMembership");
+    Optional<URI> credentialUri = service.getCredentialUri(dto, state);
 
     if (credentialUri.isPresent()) {
       URI uri = credentialUri.get();
@@ -63,7 +62,7 @@ public class IssueResource {
   @PostMapping("/test")
   ResponseEntity<String> issueTestCredential(@RequestBody TestCredentialDto dto,
       @RequestParam(required = false) String state) {
-    Optional<URI> credentialUri = service.getCredentialUri(dto, state, "issue.TestCredential");
+    Optional<URI> credentialUri = service.getCredentialUri(dto, state);
 
     if (credentialUri.isPresent()) {
       URI uri = credentialUri.get();
@@ -71,10 +70,5 @@ public class IssueResource {
     } else {
       return ResponseEntity.internalServerError().build();
     }
-  }
-
-  record TestCredentialDto(String givenName, String familyName, LocalDate birthDate)
-      implements CredentialDataDto {
-
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/GatewayProperties.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/GatewayProperties.java
@@ -59,6 +59,7 @@ public record GatewayProperties(
      * @param issuer     The issuer of the credential token.
      * @param signingKey The key to use for signing the credential token.
      */
+    @ConfigurationProperties(prefix = "application.gateway.issuing.token")
     public record TokenProperties(String audience, String issuer, String signingKey) {
 
     }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/GatewayProperties.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/GatewayProperties.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * A representation of the credential gateway properties.
+ *
+ * @param clientId     The gateway client ID.
+ * @param clientSecret The gateway client secret.
+ * @param issuing      The issuing child properties.
+ */
+@ConfigurationProperties(prefix = "application.gateway")
+public record GatewayProperties(
+    String clientId,
+    String clientSecret,
+    IssuingProperties issuing) {
+
+  /**
+   * A representation of the gateway's issuing properties.
+   *
+   * @param parEndpoint       The gateway's PAR endpoint URI.
+   * @param authorizeEndpoint The gateway's authorize endpoint URI.
+   * @param tokenEndpoint     The gateway's token endpoint URI.
+   * @param token             The issuing token child properties.
+   * @param redirectUri       The URI to redirect to after issuing a credential.
+   */
+  public record IssuingProperties(
+      String parEndpoint,
+      String authorizeEndpoint,
+      String tokenEndpoint,
+      TokenProperties token,
+      String redirectUri) {
+
+    /**
+     * A representation of the issuing token properties.
+     *
+     * @param audience   The audience of the credential token.
+     * @param issuer     The issuer of the credential token.
+     * @param signingKey The key to use for signing the credential token.
+     */
+    public record TokenProperties(String audience, String issuer, String signingKey) {
+
+    }
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/CredentialDataDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/CredentialDataDto.java
@@ -22,11 +22,21 @@
 package uk.nhs.hee.tis.trainee.credentials.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.time.Instant;
 
 /**
  * An interface representing a DTO containing credential data.
  */
 public interface CredentialDataDto {
+
+  /**
+   * Get the expiry instant for the credential.
+   *
+   * @param issuedAt The time the credential is being issued.
+   * @return The expiry instant of the credential.
+   */
+  @JsonIgnore
+  Instant getExpiration(Instant issuedAt);
 
   /**
    * Get gateway credential type, known as scope internally.

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/CredentialDataDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/CredentialDataDto.java
@@ -1,0 +1,29 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.dto;
+
+/**
+ * An interface representing a DTO containing credential data.
+ */
+public interface CredentialDataDto {
+
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/CredentialDataDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/CredentialDataDto.java
@@ -21,9 +21,18 @@
 
 package uk.nhs.hee.tis.trainee.credentials.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 /**
  * An interface representing a DTO containing credential data.
  */
 public interface CredentialDataDto {
 
+  /**
+   * Get gateway credential type, known as scope internally.
+   *
+   * @return The credential's scope.
+   */
+  @JsonIgnore
+  String getScope();
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/ProgrammeMembershipDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/ProgrammeMembershipDto.java
@@ -23,7 +23,10 @@ package uk.nhs.hee.tis.trainee.credentials.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
 
 /**
  * A DTO representing Programme Membership credential data.
@@ -38,6 +41,11 @@ public record ProgrammeMembershipDto(
     String programmeName,
     LocalDate startDate,
     LocalDate endDate) implements CredentialDataDto {
+
+  @Override
+  public Instant getExpiration(Instant issuedAt) {
+    return endDate.atTime(LocalTime.MAX).toInstant(ZoneOffset.UTC);
+  }
 
   @Override
   public String getScope() {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/ProgrammeMembershipDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/ProgrammeMembershipDto.java
@@ -1,0 +1,42 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
+import java.time.LocalDate;
+
+/**
+ * A DTO representing Programme Membership credential data.
+ *
+ * @param programmeName The programme name.
+ * @param startDate     The programme's start date.
+ * @param endDate       The programme's end date.
+ */
+public record ProgrammeMembershipDto(
+    @JsonProperty(access = Access.WRITE_ONLY)
+    String tisId,
+    String programmeName,
+    LocalDate startDate,
+    LocalDate endDate) implements CredentialDataDto {
+
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/TestCredentialDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/TestCredentialDto.java
@@ -21,26 +21,20 @@
 
 package uk.nhs.hee.tis.trainee.credentials.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import java.time.LocalDate;
 
 /**
- * A DTO representing Programme Membership credential data.
+ * A DTO representing test credential data.
  *
- * @param programmeName The programme name.
- * @param startDate     The programme's start date.
- * @param endDate       The programme's end date.
+ * @param givenName  A given name.
+ * @param familyName A family name.
+ * @param birthDate  The birthdate.
  */
-public record ProgrammeMembershipDto(
-    @JsonProperty(access = Access.WRITE_ONLY)
-    String tisId,
-    String programmeName,
-    LocalDate startDate,
-    LocalDate endDate) implements CredentialDataDto {
+public record TestCredentialDto(String givenName, String familyName, LocalDate birthDate)
+    implements CredentialDataDto {
 
   @Override
   public String getScope() {
-    return "issue.ProgrammeMembership";
+    return "issue.TestCredential";
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/TestCredentialDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/TestCredentialDto.java
@@ -21,7 +21,9 @@
 
 package uk.nhs.hee.tis.trainee.credentials.dto;
 
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 /**
  * A DTO representing test credential data.
@@ -32,6 +34,11 @@ import java.time.LocalDate;
  */
 public record TestCredentialDto(String givenName, String familyName, LocalDate birthDate)
     implements CredentialDataDto {
+
+  @Override
+  public Instant getExpiration(Instant issuedAt) {
+    return issuedAt.atOffset(ZoneOffset.UTC).plusYears(1).toInstant();
+  }
 
   @Override
   public String getScope() {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayService.java
@@ -1,0 +1,141 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.service;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDataDto;
+
+/**
+ * A service providing credential gateway functionality.
+ */
+@Service
+public class GatewayService {
+
+  private final RestTemplate restTemplate;
+  private final JwtService jwtService;
+  private final GatewayProperties properties;
+
+  /**
+   * Create a service providing credential gateway functionality.
+   *
+   * @param restTemplate The rest template for sending requests to the gateway.
+   * @param jwtService   The service to use to build JWT.
+   * @param properties   The gateway application configuration.
+   */
+  GatewayService(RestTemplate restTemplate, JwtService jwtService, GatewayProperties properties) {
+    this.restTemplate = restTemplate;
+    this.jwtService = jwtService;
+    this.properties = properties;
+  }
+
+  /**
+   * Get a URI to be used to issue a credential for the given credential data.
+   *
+   * @param dto   The credential data to be issued.
+   * @param state The client state.
+   * @param scope The gateway credential type.
+   * @return The URI to issue the credential.
+   */
+  public Optional<URI> getCredentialUri(CredentialDataDto dto, String state, String scope) {
+    HttpEntity<MultiValueMap<String, String>> request = buildParRequest(dto, state, scope);
+    ResponseEntity<ParResponse> response = restTemplate.postForEntity(
+        properties.issuing().parEndpoint(), request, ParResponse.class);
+    return buildCredentialUri(response);
+  }
+
+  /**
+   * Build a request to send to the PAR endpoint.
+   *
+   * @param dto   The dto to build a credential for.
+   * @param state The client state.
+   * @param scope The gateway credential type.
+   * @return The built request.
+   */
+  private HttpEntity<MultiValueMap<String, String>> buildParRequest(CredentialDataDto dto,
+      String state,
+      String scope) {
+    String idTokenHint = jwtService.generateToken(dto);
+
+    String nonce = UUID.randomUUID().toString();
+    MultiValueMap<String, String> bodyPair = new LinkedMultiValueMap<>();
+    bodyPair.add("client_id", properties.clientId());
+    bodyPair.add("client_secret", properties.clientSecret());
+    bodyPair.add("redirect_uri", properties.issuing().redirectUri());
+    bodyPair.add("scope", scope);
+    bodyPair.add("id_token_hint", idTokenHint);
+    bodyPair.add("nonce", nonce);
+    bodyPair.add("state", state);
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+    return new HttpEntity<>(bodyPair, headers);
+  }
+
+  /**
+   * Build a credential URI from the response of a PAR request.
+   *
+   * @param response The response to process.
+   * @return The credential URI, or empty optional if the response was invalid.
+   */
+  private Optional<URI> buildCredentialUri(ResponseEntity<ParResponse> response) {
+    URI credentialUri = null;
+
+    if (response.getStatusCode().equals(HttpStatus.CREATED)) {
+      ParResponse parResponse = response.getBody();
+
+      if (parResponse != null) {
+        credentialUri = UriComponentsBuilder.fromUriString(properties.issuing().authorizeEndpoint())
+            .queryParam("request_uri", parResponse.requestUri())
+            .build()
+            .toUri();
+      }
+    }
+
+    return Optional.ofNullable(credentialUri);
+  }
+
+  /**
+   * A record representing a successful response to a PAR request.
+   *
+   * @param requestUri The returned request_uri value.
+   */
+  record ParResponse(@JsonProperty("request_uri") String requestUri) {
+
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayService.java
@@ -67,11 +67,10 @@ public class GatewayService {
    *
    * @param dto   The credential data to be issued.
    * @param state The client state.
-   * @param scope The gateway credential type.
    * @return The URI to issue the credential.
    */
-  public Optional<URI> getCredentialUri(CredentialDataDto dto, String state, String scope) {
-    HttpEntity<MultiValueMap<String, String>> request = buildParRequest(dto, state, scope);
+  public Optional<URI> getCredentialUri(CredentialDataDto dto, String state) {
+    HttpEntity<MultiValueMap<String, String>> request = buildParRequest(dto, state);
     ResponseEntity<ParResponse> response = restTemplate.postForEntity(
         properties.issuing().parEndpoint(), request, ParResponse.class);
     return buildCredentialUri(response);
@@ -82,12 +81,10 @@ public class GatewayService {
    *
    * @param dto   The dto to build a credential for.
    * @param state The client state.
-   * @param scope The gateway credential type.
    * @return The built request.
    */
   private HttpEntity<MultiValueMap<String, String>> buildParRequest(CredentialDataDto dto,
-      String state,
-      String scope) {
+      String state) {
     String idTokenHint = jwtService.generateToken(dto);
 
     String nonce = UUID.randomUUID().toString();
@@ -95,7 +92,7 @@ public class GatewayService {
     bodyPair.add("client_id", properties.clientId());
     bodyPair.add("client_secret", properties.clientSecret());
     bodyPair.add("redirect_uri", properties.issuing().redirectUri());
-    bodyPair.add("scope", scope);
+    bodyPair.add("scope", dto.getScope());
     bodyPair.add("id_token_hint", idTokenHint);
     bodyPair.add("nonce", nonce);
     bodyPair.add("state", state);

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/JwtService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/JwtService.java
@@ -1,0 +1,80 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
+import javax.crypto.SecretKey;
+import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties.IssuingProperties.TokenProperties;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDataDto;
+
+/**
+ * A service providing JWT token functionality.
+ */
+@Service
+public class JwtService {
+
+  private final ObjectMapper mapper;
+  private final TokenProperties properties;
+
+  /**
+   * Create a service providing JWT token functionality.
+   *
+   * @param mapper     The mapper to convert data.
+   * @param properties The token properties.
+   */
+  JwtService(ObjectMapper mapper, TokenProperties properties) {
+    this.mapper = mapper;
+    this.properties = properties;
+  }
+
+  /**
+   * Generate a token including the given credential claims alongside the default JWT claims.
+   *
+   * @param dto The credential data to include in the token claims.
+   * @return The generated token as an encoded string.
+   */
+  public String generateToken(CredentialDataDto dto) {
+    Instant now = Instant.now();
+    Instant expiry = now.atOffset(ZoneOffset.UTC).plusYears(1).toInstant();
+
+    Map<String, Object> claimsMap = mapper.convertValue(dto, Map.class);
+    SecretKey signingKey = Keys.hmacShaKeyFor(Base64.getDecoder().decode(properties.signingKey()));
+
+    return Jwts.builder()
+        .setAudience(properties.audience())
+        .setIssuer(properties.issuer())
+        .setIssuedAt(Date.from(now))
+        .setNotBefore(Date.from(now))
+        .setExpiration(Date.from(expiry))
+        .addClaims(claimsMap)
+        .signWith(signingKey)
+        .compact();
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/JwtService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/JwtService.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.Base64;
 import java.util.Date;
 import java.util.Map;
@@ -62,8 +61,6 @@ public class JwtService {
    */
   public String generateToken(CredentialDataDto dto) {
     Instant now = Instant.now();
-    Instant expiry = now.atOffset(ZoneOffset.UTC).plusYears(1).toInstant();
-
     Map<String, Object> claimsMap = mapper.convertValue(dto, Map.class);
     SecretKey signingKey = Keys.hmacShaKeyFor(Base64.getDecoder().decode(properties.signingKey()));
 
@@ -72,7 +69,7 @@ public class JwtService {
         .setIssuer(properties.issuer())
         .setIssuedAt(Date.from(now))
         .setNotBefore(Date.from(now))
-        .setExpiration(Date.from(expiry))
+        .setExpiration(Date.from(dto.getExpiration(now)))
         .addClaims(claimsMap)
         .signWith(signingKey)
         .compact();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,20 @@ server:
     context-path: /credentials
 
 application:
+  gateway:
+    host: ${GATEWAY_HOST}
+    client-id: ${GATEWAY_CLIENT_ID}
+    client-secret: ${GATEWAY_CLIENT_SECRET}
+    issuing:
+      par-endpoint: https://${application.gateway.host}/issuing/par
+      authorize-endpoint: https://${application.gateway.host}/issuing/authorize?client_id=${application.gateway.client-id}
+      token-endpoint: https://${application.gateway.host}/issuing/token
+      token:
+        audience: https://${application.gateway.host}/issuing
+        issuer: ${GATEWAY_TOKEN_ISSUER}
+        signing-key: ${GATEWAY_TOKEN_SIGNING_KEY}
+      redirect-uri: ${GATEWAY_ISSUING_REDIRECT_URI}
+
   signature:
     secret-key: ${SIGNATURE_SECRET_KEY}
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResourceTest.java
@@ -29,6 +29,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.nhs.hee.tis.trainee.credentials.SignatureTestUtil;
@@ -72,5 +75,12 @@ class IssueResourceTest {
                 .content(signedData)
                 .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk());
+  }
+
+  @TestConfiguration
+  static class TestConfig {
+
+    @MockBean
+    private RestTemplateBuilder restTemplateBuilder;
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayServiceTest.java
@@ -56,7 +56,6 @@ class GatewayServiceTest {
   private static final String REDIRECT_URI = "https://redirect.uri";
 
   private static final String STATE = "some-client-state";
-  private static final String SCOPE = "issue.TestCredential";
 
   private GatewayService service;
   private JwtService jwtService;
@@ -85,7 +84,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
         eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
 
-    service.getCredentialUri(dto, STATE, SCOPE);
+    service.getCredentialUri(dto, STATE);
 
     HttpHeaders headers = argumentCaptor.getValue().getHeaders();
     assertThat("Unexpected accept header.", headers.get(HttpHeaders.ACCEPT),
@@ -102,7 +101,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
         eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
 
-    service.getCredentialUri(dto, STATE, SCOPE);
+    service.getCredentialUri(dto, STATE);
 
     HttpHeaders headers = argumentCaptor.getValue().getHeaders();
     assertThat("Unexpected content type header.", headers.get(HttpHeaders.CONTENT_TYPE),
@@ -117,7 +116,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
         eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
 
-    service.getCredentialUri(dto, STATE, SCOPE);
+    service.getCredentialUri(dto, STATE);
 
     var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
     MultiValueMap<String, String> requestBody = request.getBody();
@@ -132,7 +131,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
         eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
 
-    service.getCredentialUri(dto, STATE, SCOPE);
+    service.getCredentialUri(dto, STATE);
 
     var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
     MultiValueMap<String, String> requestBody = request.getBody();
@@ -148,7 +147,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
         eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
 
-    service.getCredentialUri(dto, STATE, SCOPE);
+    service.getCredentialUri(dto, STATE);
 
     var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
     MultiValueMap<String, String> requestBody = request.getBody();
@@ -159,16 +158,17 @@ class GatewayServiceTest {
   @Test
   void shouldIncludeScopeInParRequest() {
     CredentialDataDto dto = mock(CredentialDataDto.class);
+    when(dto.getScope()).thenReturn("test.scope.value");
 
     var argumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
         eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
 
-    service.getCredentialUri(dto, STATE, SCOPE);
+    service.getCredentialUri(dto, STATE);
 
     var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
     MultiValueMap<String, String> requestBody = request.getBody();
-    assertThat("Unexpected scope.", requestBody.get("scope"), is(List.of(SCOPE)));
+    assertThat("Unexpected scope.", requestBody.get("scope"), is(List.of("test.scope.value")));
   }
 
   @Test
@@ -179,7 +179,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
         eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
 
-    service.getCredentialUri(dto, STATE, SCOPE);
+    service.getCredentialUri(dto, STATE);
 
     var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
     MultiValueMap<String, String> requestBody = request.getBody();
@@ -194,7 +194,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
         eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
 
-    service.getCredentialUri(dto, STATE, SCOPE);
+    service.getCredentialUri(dto, STATE);
 
     var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
     MultiValueMap<String, String> requestBody = request.getBody();
@@ -211,7 +211,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
         eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
 
-    service.getCredentialUri(dto, STATE, SCOPE);
+    service.getCredentialUri(dto, STATE);
 
     var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
     MultiValueMap<String, String> requestBody = request.getBody();
@@ -226,7 +226,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), any(), eq(ParResponse.class))).thenReturn(
         ResponseEntity.notFound().build());
 
-    Optional<URI> optional = service.getCredentialUri(dto, STATE, SCOPE);
+    Optional<URI> optional = service.getCredentialUri(dto, STATE);
 
     assertThat("Unexpected URI presence.", optional.isPresent(), is(false));
   }
@@ -239,7 +239,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), any(), eq(ParResponse.class))).thenReturn(
         response);
 
-    Optional<URI> optional = service.getCredentialUri(dto, STATE, SCOPE);
+    Optional<URI> optional = service.getCredentialUri(dto, STATE);
 
     assertThat("Unexpected URI presence.", optional.isPresent(), is(false));
   }
@@ -253,7 +253,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), any(), eq(ParResponse.class))).thenReturn(
         response);
 
-    Optional<URI> optional = service.getCredentialUri(dto, STATE, SCOPE);
+    Optional<URI> optional = service.getCredentialUri(dto, STATE);
 
     assertThat("Unexpected URI presence.", optional.isPresent(), is(true));
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayServiceTest.java
@@ -1,0 +1,265 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties;
+import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties.IssuingProperties;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDataDto;
+import uk.nhs.hee.tis.trainee.credentials.service.GatewayService.ParResponse;
+
+class GatewayServiceTest {
+
+  private static final String CLIENT_ID = "client-id";
+  private static final String CLIENT_SECRET = "no-very-secret";
+  private static final String AUTHORIZE_ENDPOINT = "https://credential.gateway/authorize/endpoint";
+  private static final String PAR_ENDPOINT = "https://credential.gateway/par/endpoint";
+  private static final String REDIRECT_URI = "https://redirect.uri";
+
+  private static final String STATE = "some-client-state";
+  private static final String SCOPE = "issue.TestCredential";
+
+  private GatewayService service;
+  private JwtService jwtService;
+  private RestTemplate restTemplate;
+
+  @BeforeEach
+  void setUp() {
+    restTemplate = mock(RestTemplate.class);
+    jwtService = mock(JwtService.class);
+
+    IssuingProperties issuingProperties = new IssuingProperties(PAR_ENDPOINT, AUTHORIZE_ENDPOINT,
+        "", null, REDIRECT_URI);
+    GatewayProperties gatewayProperties = new GatewayProperties(CLIENT_ID, CLIENT_SECRET,
+        issuingProperties);
+
+    service = new GatewayService(restTemplate, jwtService, gatewayProperties);
+  }
+
+  @Test
+  void shouldIncludeAcceptHeaderInParRequest() {
+    CredentialDataDto dto = mock(CredentialDataDto.class);
+
+    when(jwtService.generateToken(dto)).thenReturn("id_token_hint_value");
+
+    var argumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
+        eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
+
+    service.getCredentialUri(dto, STATE, SCOPE);
+
+    HttpHeaders headers = argumentCaptor.getValue().getHeaders();
+    assertThat("Unexpected accept header.", headers.get(HttpHeaders.ACCEPT),
+        is(List.of(MediaType.APPLICATION_JSON_VALUE)));
+  }
+
+  @Test
+  void shouldIncludeContentTypeHeaderInParRequest() {
+    CredentialDataDto dto = mock(CredentialDataDto.class);
+
+    when(jwtService.generateToken(dto)).thenReturn("id_token_hint_value");
+
+    var argumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
+        eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
+
+    service.getCredentialUri(dto, STATE, SCOPE);
+
+    HttpHeaders headers = argumentCaptor.getValue().getHeaders();
+    assertThat("Unexpected content type header.", headers.get(HttpHeaders.CONTENT_TYPE),
+        is(List.of(MediaType.APPLICATION_FORM_URLENCODED_VALUE)));
+  }
+
+  @Test
+  void shouldIncludeClientIdInParRequest() {
+    CredentialDataDto dto = mock(CredentialDataDto.class);
+
+    var argumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
+        eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
+
+    service.getCredentialUri(dto, STATE, SCOPE);
+
+    var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
+    MultiValueMap<String, String> requestBody = request.getBody();
+    assertThat("Unexpected client ID.", requestBody.get("client_id"), is(List.of(CLIENT_ID)));
+  }
+
+  @Test
+  void shouldIncludeClientSecretInParRequest() {
+    CredentialDataDto dto = mock(CredentialDataDto.class);
+
+    var argumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
+        eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
+
+    service.getCredentialUri(dto, STATE, SCOPE);
+
+    var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
+    MultiValueMap<String, String> requestBody = request.getBody();
+    assertThat("Unexpected client secret.", requestBody.get("client_secret"),
+        is(List.of(CLIENT_SECRET)));
+  }
+
+  @Test
+  void shouldIncludeRedirectUriInParRequest() {
+    CredentialDataDto dto = mock(CredentialDataDto.class);
+
+    var argumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
+        eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
+
+    service.getCredentialUri(dto, STATE, SCOPE);
+
+    var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
+    MultiValueMap<String, String> requestBody = request.getBody();
+    assertThat("Unexpected redirect URI.", requestBody.get("redirect_uri"),
+        is(List.of(REDIRECT_URI)));
+  }
+
+  @Test
+  void shouldIncludeScopeInParRequest() {
+    CredentialDataDto dto = mock(CredentialDataDto.class);
+
+    var argumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
+        eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
+
+    service.getCredentialUri(dto, STATE, SCOPE);
+
+    var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
+    MultiValueMap<String, String> requestBody = request.getBody();
+    assertThat("Unexpected scope.", requestBody.get("scope"), is(List.of(SCOPE)));
+  }
+
+  @Test
+  void shouldIncludeStateInParRequest() {
+    CredentialDataDto dto = mock(CredentialDataDto.class);
+
+    var argumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
+        eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
+
+    service.getCredentialUri(dto, STATE, SCOPE);
+
+    var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
+    MultiValueMap<String, String> requestBody = request.getBody();
+    assertThat("Unexpected state.", requestBody.get("state"), is(List.of(STATE)));
+  }
+
+  @Test
+  void shouldIncludeGeneratedNonceInParRequest() {
+    CredentialDataDto dto = mock(CredentialDataDto.class);
+
+    var argumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
+        eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
+
+    service.getCredentialUri(dto, STATE, SCOPE);
+
+    var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
+    MultiValueMap<String, String> requestBody = request.getBody();
+    assertThat("Unexpected nonce.", requestBody.get("nonce"), notNullValue());
+  }
+
+  @Test
+  void shouldIncludeIdTokenHintInParRequest() {
+    CredentialDataDto dto = mock(CredentialDataDto.class);
+
+    when(jwtService.generateToken(dto)).thenReturn("id_token_hint_value");
+
+    var argumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
+        eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
+
+    service.getCredentialUri(dto, STATE, SCOPE);
+
+    var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
+    MultiValueMap<String, String> requestBody = request.getBody();
+    assertThat("Unexpected id token hint.", requestBody.get("id_token_hint"),
+        is(List.of("id_token_hint_value")));
+  }
+
+  @Test
+  void shouldReturnEmptyUriWhenParResponseCodeNotCreated() {
+    CredentialDataDto dto = mock(CredentialDataDto.class);
+
+    when(restTemplate.postForEntity(eq(PAR_ENDPOINT), any(), eq(ParResponse.class))).thenReturn(
+        ResponseEntity.notFound().build());
+
+    Optional<URI> optional = service.getCredentialUri(dto, STATE, SCOPE);
+
+    assertThat("Unexpected URI presence.", optional.isPresent(), is(false));
+  }
+
+  @Test
+  void shouldReturnEmptyUriWhenParResponseEmpty() {
+    CredentialDataDto dto = mock(CredentialDataDto.class);
+
+    var response = ResponseEntity.status(HttpStatus.CREATED).body((ParResponse) null);
+    when(restTemplate.postForEntity(eq(PAR_ENDPOINT), any(), eq(ParResponse.class))).thenReturn(
+        response);
+
+    Optional<URI> optional = service.getCredentialUri(dto, STATE, SCOPE);
+
+    assertThat("Unexpected URI presence.", optional.isPresent(), is(false));
+  }
+
+  @Test
+  void shouldReturnUriWhenParResponseNotEmpty() {
+    CredentialDataDto dto = mock(CredentialDataDto.class);
+
+    String requestUri = "a-new-request-uri";
+    var response = ResponseEntity.status(HttpStatus.CREATED).body(new ParResponse(requestUri));
+    when(restTemplate.postForEntity(eq(PAR_ENDPOINT), any(), eq(ParResponse.class))).thenReturn(
+        response);
+
+    Optional<URI> optional = service.getCredentialUri(dto, STATE, SCOPE);
+
+    assertThat("Unexpected URI presence.", optional.isPresent(), is(true));
+
+    URI credentialUri = optional.get();
+    URI relativeUri = credentialUri.relativize(URI.create(AUTHORIZE_ENDPOINT));
+    assertThat("Unexpected relative URI.", relativeUri, is(URI.create("")));
+    assertThat("Unexpected URI query.", credentialUri.getQuery(), is("request_uri=" + requestUri));
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/JwtServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/JwtServiceTest.java
@@ -82,6 +82,10 @@ class JwtServiceTest {
   void shouldGenerateTokenWithDefaultClaims() {
     record EmptyData() implements CredentialDataDto {
 
+      @Override
+      public String getScope() {
+        return "issue.Empty";
+      }
     }
 
     final Instant now = Instant.now();

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/JwtServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/JwtServiceTest.java
@@ -33,13 +33,13 @@ import io.jsonwebtoken.Jwt;
 import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.util.Base64;
 import java.util.Date;
 import javax.crypto.SecretKey;
 import org.junit.jupiter.api.BeforeEach;
@@ -68,10 +68,10 @@ class JwtServiceTest {
     mapper.registerModule(new JavaTimeModule());
     mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
-    byte[] keyBytes = new byte[256];
+    byte[] keyBytes = new byte[32];
     SecureRandom.getInstanceStrong().nextBytes(keyBytes);
-    String keyString = new String(keyBytes, StandardCharsets.UTF_8);
-    SecretKey key = Keys.hmacShaKeyFor(keyString.getBytes(StandardCharsets.UTF_8));
+    String keyString = Base64.getEncoder().encodeToString(keyBytes);
+    SecretKey key = Keys.hmacShaKeyFor(keyBytes);
     parser = Jwts.parserBuilder().setSigningKey(key).build();
 
     TokenProperties properties = new TokenProperties(AUDIENCE, ISSUER, keyString);

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/JwtServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/JwtServiceTest.java
@@ -1,0 +1,125 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwt;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties.IssuingProperties.TokenProperties;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDataDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.ProgrammeMembershipDto;
+
+class JwtServiceTest {
+
+  private static final String PROGRAMME_NAME = "Programme One";
+  private static final LocalDate START_DATE = LocalDate.now().minusYears(1);
+  private static final LocalDate END_DATE = LocalDate.now().plusYears(1);
+
+  private static final String AUDIENCE = "https://test.tis.nhs.uk/audience";
+  private static final String ISSUER = "some-identifier";
+
+  private static final int DEFAULT_CLAIM_COUNT = 5;
+
+  private JwtService service;
+  private JwtParser parser;
+
+  @BeforeEach
+  void setUp() throws NoSuchAlgorithmException {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new JavaTimeModule());
+    mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    byte[] keyBytes = new byte[256];
+    SecureRandom.getInstanceStrong().nextBytes(keyBytes);
+    String keyString = new String(keyBytes, StandardCharsets.UTF_8);
+    SecretKey key = Keys.hmacShaKeyFor(keyString.getBytes(StandardCharsets.UTF_8));
+    parser = Jwts.parserBuilder().setSigningKey(key).build();
+
+    TokenProperties properties = new TokenProperties(AUDIENCE, ISSUER, keyString);
+    service = new JwtService(mapper, properties);
+  }
+
+  @Test
+  void shouldGenerateTokenWithDefaultClaims() {
+    record EmptyData() implements CredentialDataDto {
+
+    }
+
+    final Instant now = Instant.now();
+    String tokenString = service.generateToken(new EmptyData());
+
+    Jwt<?, Claims> token = parser.parse(tokenString);
+    Claims tokenClaims = token.getBody();
+
+    assertThat("Unexpected number of claims.", tokenClaims.size(), is(DEFAULT_CLAIM_COUNT));
+    assertThat("Unexpected token aud.", tokenClaims.getAudience(), is(AUDIENCE));
+    assertThat("Unexpected token iss.", tokenClaims.getIssuer(), is(ISSUER));
+
+    Date issuedAt = tokenClaims.getIssuedAt();
+    long issuedAtDiff = Duration.between(issuedAt.toInstant(), now).toMinutes();
+    assertThat("Unexpected difference between now and iat.", issuedAtDiff, is(0L));
+    assertThat("Unexpected token nbf.", tokenClaims.getNotBefore(), is(issuedAt));
+
+    Date expectedExpiry = Date.from(
+        issuedAt.toInstant().atOffset(ZoneOffset.UTC).plusYears(1).toInstant());
+    assertThat("Unexpected token exp.", tokenClaims.getExpiration(), is(expectedExpiry));
+  }
+
+  @Test
+  void shouldGenerateTokenWithProgrammeMembershipClaims() {
+    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(
+        "123", PROGRAMME_NAME, START_DATE, END_DATE);
+
+    String tokenString = service.generateToken(dto);
+
+    Jwt<?, Claims> token = parser.parse(tokenString);
+    Claims tokenClaims = token.getBody();
+
+    assertThat("Unexpected number of claims.", tokenClaims.size(), is(DEFAULT_CLAIM_COUNT + 3));
+    assertThat("Unexpected claim.", tokenClaims.get("tisId"), nullValue());
+    assertThat("Unexpected programme name.", tokenClaims.get("programmeName"), is(PROGRAMME_NAME));
+    assertThat("Unexpected programme start date.", tokenClaims.get("startDate"),
+        is(START_DATE.toString()));
+    assertThat("Unexpected programme end date.", tokenClaims.get("endDate"),
+        is(END_DATE.toString()));
+  }
+}


### PR DESCRIPTION
Add services for issuing a credential to the DSP gateway and providing the caller with a URI which can be used to download the credential to their wallet.

The programme membership endpoint will not function until some gateway config is done, after which changes may be needed if the assumptions made (credential scope, fields etc.) do not match up.

This is ready for review but raised as a draft due to being built on top of the branch submitted to #3

TIS21-4066
TIS21-4070