### PR TITLE
fix: add logging to the issue credential flow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.2.0"
+version = "0.2.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResource.java
@@ -23,6 +23,7 @@ package uk.nhs.hee.tis.trainee.credentials.api;
 
 import java.net.URI;
 import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -36,6 +37,7 @@ import uk.nhs.hee.tis.trainee.credentials.service.GatewayService;
 /**
  * API endpoints for issuing trainee digital credentials.
  */
+@Slf4j
 @RestController()
 @RequestMapping("/api/issue")
 public class IssueResource {
@@ -49,12 +51,15 @@ public class IssueResource {
   @PostMapping("/programme-membership")
   ResponseEntity<String> issueProgrammeMembershipCredential(@RequestBody ProgrammeMembershipDto dto,
       @RequestParam(required = false) String state) {
+    log.info("Received request to issue Programme Membership credential.");
     Optional<URI> credentialUri = service.getCredentialUri(dto, state);
 
     if (credentialUri.isPresent()) {
       URI uri = credentialUri.get();
+      log.info("Programme Membership credential successfully issued.");
       return ResponseEntity.created(uri).body(uri.toString());
     } else {
+      log.error("Could not issue Programme Membership credential.");
       return ResponseEntity.internalServerError().build();
     }
   }
@@ -62,12 +67,15 @@ public class IssueResource {
   @PostMapping("/test")
   ResponseEntity<String> issueTestCredential(@RequestBody TestCredentialDto dto,
       @RequestParam(required = false) String state) {
+    log.info("Received request to issue Test credential.");
     Optional<URI> credentialUri = service.getCredentialUri(dto, state);
 
     if (credentialUri.isPresent()) {
       URI uri = credentialUri.get();
+      log.info("Test credential successfully issued.");
       return ResponseEntity.created(uri).body(uri.toString());
     } else {
+      log.error("Could not issue Test credential.");
       return ResponseEntity.internalServerError().build();
     }
   }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/JwtService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/JwtService.java
@@ -29,6 +29,7 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.Map;
 import javax.crypto.SecretKey;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties.IssuingProperties.TokenProperties;
 import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDataDto;
@@ -36,6 +37,7 @@ import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDataDto;
 /**
  * A service providing JWT token functionality.
  */
+@Slf4j
 @Service
 public class JwtService {
 
@@ -60,11 +62,12 @@ public class JwtService {
    * @return The generated token as an encoded string.
    */
   public String generateToken(CredentialDataDto dto) {
+    log.info("Generating id_token_hint JWT.");
     Instant now = Instant.now();
     Map<String, Object> claimsMap = mapper.convertValue(dto, Map.class);
     SecretKey signingKey = Keys.hmacShaKeyFor(Base64.getDecoder().decode(properties.signingKey()));
 
-    return Jwts.builder()
+    String jwt = Jwts.builder()
         .setAudience(properties.audience())
         .setIssuer(properties.issuer())
         .setIssuedAt(Date.from(now))
@@ -73,5 +76,8 @@ public class JwtService {
         .addClaims(claimsMap)
         .signWith(signingKey)
         .compact();
+
+    log.info("Generated id_token_hint JWT.");
+    return jwt;
   }
 }


### PR DESCRIPTION
Add logging for the credential issuing flow, the logging should be fairly generic and high level initially. Care needs to be taken about what identifiers are logged (state, nonce etc.) due to possible security issues should someone have access to our logs.
Over time it will become clearer what credential identifying information needs to be included to allow debugging.

TIS21-4066
TIS21-4070