### PR TITLE
feat: add DTO validation to issue endpoints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.3.0"
+version = "0.4.0"
 
 configurations {
   compileOnly {
@@ -26,6 +26,7 @@ dependencies {
   // Spring Boot starters
   implementation "org.springframework.boot:spring-boot-starter-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
+  implementation "org.springframework.boot:spring-boot-starter-validation"
   testImplementation "org.springframework.boot:spring-boot-starter-test"
 
   // Lombok

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResource.java
@@ -25,6 +25,7 @@ import java.net.URI;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -50,7 +51,8 @@ public class IssueResource {
   }
 
   @PostMapping("/programme-membership")
-  ResponseEntity<String> issueProgrammeMembershipCredential(@RequestBody ProgrammeMembershipDto dto,
+  ResponseEntity<String> issueProgrammeMembershipCredential(
+      @Validated @RequestBody ProgrammeMembershipDto dto,
       @RequestParam(required = false) String state) {
     log.info("Received request to issue Programme Membership credential.");
     Optional<URI> credentialUri = service.getCredentialUri(dto, state);
@@ -66,8 +68,9 @@ public class IssueResource {
   }
 
   @PostMapping("/placement")
-  ResponseEntity<String> issuePlacementCredential(@RequestBody PlacementDto dto,
-                                                  @RequestParam(required = false) String state) {
+  ResponseEntity<String> issuePlacementCredential(
+      @Validated @RequestBody PlacementDto dto,
+      @RequestParam(required = false) String state) {
     Optional<URI> credentialUri = service.getCredentialUri(dto, state);
     log.info("Received request to issue Placement credential.");
     if (credentialUri.isPresent()) {
@@ -81,7 +84,8 @@ public class IssueResource {
   }
 
   @PostMapping("/test")
-  ResponseEntity<String> issueTestCredential(@RequestBody TestCredentialDto dto,
+  ResponseEntity<String> issueTestCredential(
+      @Validated @RequestBody TestCredentialDto dto,
       @RequestParam(required = false) String state) {
     log.info("Received request to issue Test credential.");
     Optional<URI> credentialUri = service.getCredentialUri(dto, state);

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/PlacementDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/PlacementDto.java
@@ -23,6 +23,8 @@ package uk.nhs.hee.tis.trainee.credentials.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -41,14 +43,14 @@ import java.time.ZoneOffset;
  */
 public record PlacementDto(
     @JsonProperty(access = Access.WRITE_ONLY)
-    String tisId,
-    String specialty,
-    String grade,
-    String nationalPostNumber,
-    String employingBody,
-    String site,
-    LocalDate startDate,
-    LocalDate endDate) implements CredentialDataDto {
+    @NotEmpty String tisId,
+    @NotEmpty String specialty,
+    @NotEmpty String grade,
+    @NotEmpty String nationalPostNumber,
+    @NotEmpty String employingBody,
+    @NotEmpty String site,
+    @NotNull LocalDate startDate,
+    @NotNull LocalDate endDate) implements CredentialDataDto {
 
   @Override
   public Instant getExpiration(Instant issuedAt) {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/ProgrammeMembershipDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/ProgrammeMembershipDto.java
@@ -23,6 +23,8 @@ package uk.nhs.hee.tis.trainee.credentials.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -37,10 +39,10 @@ import java.time.ZoneOffset;
  */
 public record ProgrammeMembershipDto(
     @JsonProperty(access = Access.WRITE_ONLY)
-    String tisId,
-    String programmeName,
-    LocalDate startDate,
-    LocalDate endDate) implements CredentialDataDto {
+    @NotEmpty String tisId,
+    @NotEmpty String programmeName,
+    @NotNull LocalDate startDate,
+    @NotNull LocalDate endDate) implements CredentialDataDto {
 
   @Override
   public Instant getExpiration(Instant issuedAt) {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/TestCredentialDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/TestCredentialDto.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.tis.trainee.credentials.dto;
 
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
@@ -32,8 +34,10 @@ import java.time.ZoneOffset;
  * @param familyName A family name.
  * @param birthDate  The birthdate.
  */
-public record TestCredentialDto(String givenName, String familyName, LocalDate birthDate)
-    implements CredentialDataDto {
+public record TestCredentialDto(
+    @NotEmpty String givenName,
+    @NotEmpty String familyName,
+    @NotNull LocalDate birthDate) implements CredentialDataDto {
 
   @Override
   public Instant getExpiration(Instant issuedAt) {

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/SignatureTestUtil.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/SignatureTestUtil.java
@@ -45,6 +45,40 @@ public class SignatureTestUtil {
   }
 
   /**
+   * A helper method to remove a field from the data and then sign it with a valid HMAC.
+   *
+   * @param dataToSign       The data to sign.
+   * @param secretKey        The secret key to sign the data with.
+   * @param fieldToOverwrite The field to overwrite in the data before signing.
+   * @param newFieldValue    The new value of the overwritten field.
+   * @return A string representation of the signed data.
+   * @throws JsonProcessingException If the dataToSign was not valid JSON.
+   */
+  public static String overwriteFieldAndSignData(String dataToSign, String secretKey,
+      String fieldToOverwrite, String newFieldValue) throws JsonProcessingException {
+    ObjectNode nodeToSign = (ObjectNode) MAPPER.readTree(dataToSign);
+    nodeToSign.put(fieldToOverwrite, newFieldValue);
+    return signData(nodeToSign, secretKey);
+  }
+
+  /**
+   * A helper method to remove a field from the data and then sign it with a valid HMAC.
+   *
+   * @param dataToSign    The data to sign.
+   * @param secretKey     The secret key to sign the data with.
+   * @param fieldToRemove The field to remove from the data before signing.
+   * @return A string representation of the signed data.
+   * @throws JsonProcessingException If the dataToSign was not valid JSON.
+   */
+  public static String removeFieldAndSignData(String dataToSign, String secretKey,
+      String fieldToRemove) throws JsonProcessingException {
+    ObjectNode nodeToSign = (ObjectNode) MAPPER.readTree(dataToSign);
+    nodeToSign.remove(fieldToRemove);
+
+    return signData(nodeToSign, secretKey);
+  }
+
+  /**
    * A helper method to sign test data with a valid HMAC.
    *
    * @param dataToSign The data to sign.
@@ -55,6 +89,19 @@ public class SignatureTestUtil {
   public static String signData(String dataToSign, String secretKey)
       throws JsonProcessingException {
     JsonNode nodeToSign = MAPPER.readTree(dataToSign);
+    return signData(nodeToSign, secretKey);
+  }
+
+  /**
+   * A helper method to sign test data with a valid HMAC.
+   *
+   * @param nodeToSign The data to sign.
+   * @param secretKey  The secret key to sign the data with.
+   * @return A string representation of the signed data.
+   * @throws JsonProcessingException If the dataToSign was not valid JSON.
+   */
+  private static String signData(JsonNode nodeToSign, String secretKey)
+      throws JsonProcessingException {
     ObjectNode signatureNode = (ObjectNode) nodeToSign.get(SIGNATURE_FIELD);
 
     byte[] bytesToSign = MAPPER.writeValueAsBytes(nodeToSign);


### PR DESCRIPTION
Currently it is possible to send any signed data to any issue endpoint and it would be accepted. For example sending a placement to the programme membership endpoint would populate the `tisId`, `startDate` and `endDate` leaving the `programmeName` as `null`. The gateway appears to accept
null/empty/missing fields in the credential, so we must validate them ourselves to avoid any issues. In our example of sending a placement to the programme membership endpoint it would result in a seemingly valid Programme Membership credential being issued with no programme name and other field values from unrelated data.

Add validation to the issue endpoints to avoid empty fields being accepted.

TIS21-4066
TIS21-4070
TIS21-4071
TIS21-4074