### PR TITLE
Fix/programme credential naming

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -17,10 +17,6 @@
           "valueFrom": "/tis/trainee/credentials/${environment}/gateway/client-secret"
         },
         {
-          "name": "GATEWAY_TOKEN_ISSUER",
-          "valueFrom": "/tis/trainee/credentials/${environment}/gateway/token-issuer"
-        },
-        {
           "name": "GATEWAY_TOKEN_SIGNING_KEY",
           "valueFrom": "/tis/trainee/credentials/${environment}/gateway/token-signing-key"
         },

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ gradlew bootRun
 | GATEWAY_HOST                 | The credential gateway host.                              |           |
 | GATEWAY_CLIENT_ID            | The client ID for the credential gateway.                 |           |
 | GATEWAY_CLIENT_SECRET        | The client secret for the credential gateway.             |           |
-| GATEWAY_TOKEN_ISSUER         | The issuer to add to the credential data.                 |           |
 | GATEWAY_TOKEN_SIGNING_KEY    | The Base64 encoded signing key for the credential data.   |           |
 | GATEWAY_ISSUING_REDIRECT_URI | Where the gateway issue should redirect to after issuing. |           |
 | SENTRY_DSN                   | A Sentry error monitoring Data Source Name.               |           |

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResource.java
@@ -32,8 +32,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.nhs.hee.tis.trainee.credentials.dto.PlacementDto;
-import uk.nhs.hee.tis.trainee.credentials.dto.ProgrammeMembershipDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.ProgrammeMembershipCredentialDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.ProgrammeMembershipDataDto;
 import uk.nhs.hee.tis.trainee.credentials.dto.TestCredentialDto;
+import uk.nhs.hee.tis.trainee.credentials.mapper.CredentialDataMapper;
 import uk.nhs.hee.tis.trainee.credentials.service.GatewayService;
 
 /**
@@ -45,17 +47,20 @@ import uk.nhs.hee.tis.trainee.credentials.service.GatewayService;
 public class IssueResource {
 
   private final GatewayService service;
+  private final CredentialDataMapper mapper;
 
-  IssueResource(GatewayService service) {
+  IssueResource(GatewayService service, CredentialDataMapper mapper) {
     this.service = service;
+    this.mapper = mapper;
   }
 
   @PostMapping("/programme-membership")
   ResponseEntity<String> issueProgrammeMembershipCredential(
-      @Validated @RequestBody ProgrammeMembershipDto dto,
+      @Validated @RequestBody ProgrammeMembershipDataDto dataDto,
       @RequestParam(required = false) String state) {
     log.info("Received request to issue Programme Membership credential.");
-    Optional<URI> credentialUri = service.getCredentialUri(dto, state);
+    ProgrammeMembershipCredentialDto credentialDto = mapper.toCredential(dataDto);
+    Optional<URI> credentialUri = service.getCredentialUri(credentialDto, state);
 
     if (credentialUri.isPresent()) {
       URI uri = credentialUri.get();

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/CredentialDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/CredentialDto.java
@@ -27,7 +27,7 @@ import java.time.Instant;
 /**
  * An interface representing a DTO containing credential data.
  */
-public interface CredentialDataDto {
+public interface CredentialDto {
 
   /**
    * Get the expiry instant for the credential.

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/PlacementDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/PlacementDto.java
@@ -50,7 +50,7 @@ public record PlacementDto(
     @NotEmpty String employingBody,
     @NotEmpty String site,
     @NotNull LocalDate startDate,
-    @NotNull LocalDate endDate) implements CredentialDataDto {
+    @NotNull LocalDate endDate) implements CredentialDto {
 
   @Override
   public Instant getExpiration(Instant issuedAt) {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/ProgrammeMembershipCredentialDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/ProgrammeMembershipCredentialDto.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.tis.trainee.credentials.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -34,8 +35,13 @@ import java.time.ZoneOffset;
  * @param endDate       The programme's end date.
  */
 public record ProgrammeMembershipCredentialDto(
+    @JsonProperty("TPR-Name")
     String programmeName,
+
+    @JsonProperty("TPR-ProgrammeStartDate")
     LocalDate startDate,
+
+    @JsonProperty("TPR-ProgrammeEndDate")
     LocalDate endDate
 ) implements CredentialDto {
 
@@ -46,6 +52,6 @@ public record ProgrammeMembershipCredentialDto(
 
   @Override
   public String getScope() {
-    return "issue.ProgrammeMembership";
+    return "issue.TrainingProgramme";
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/ProgrammeMembershipCredentialDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/ProgrammeMembershipCredentialDto.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.dto;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+
+/**
+ * A DTO representing a Programme Membership credential.
+ *
+ * @param programmeName The programme name.
+ * @param startDate     The programme's start date.
+ * @param endDate       The programme's end date.
+ */
+public record ProgrammeMembershipCredentialDto(
+    String programmeName,
+    LocalDate startDate,
+    LocalDate endDate
+) implements CredentialDto {
+
+  @Override
+  public Instant getExpiration(Instant issuedAt) {
+    return endDate.atTime(LocalTime.MAX).toInstant(ZoneOffset.UTC);
+  }
+
+  @Override
+  public String getScope() {
+    return "issue.ProgrammeMembership";
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/ProgrammeMembershipDataDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/ProgrammeMembershipDataDto.java
@@ -21,36 +21,22 @@
 
 package uk.nhs.hee.tis.trainee.credentials.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.ZoneOffset;
 
 /**
- * A DTO representing Programme Membership credential data.
+ * A DTO representing Programme Membership data.
  *
+ * @param tisId         The programme membership's TIS ID.
  * @param programmeName The programme name.
  * @param startDate     The programme's start date.
  * @param endDate       The programme's end date.
  */
-public record ProgrammeMembershipDto(
-    @JsonProperty(access = Access.WRITE_ONLY)
+public record ProgrammeMembershipDataDto(
     @NotEmpty String tisId,
     @NotEmpty String programmeName,
     @NotNull LocalDate startDate,
-    @NotNull LocalDate endDate) implements CredentialDto {
+    @NotNull LocalDate endDate) {
 
-  @Override
-  public Instant getExpiration(Instant issuedAt) {
-    return endDate.atTime(LocalTime.MAX).toInstant(ZoneOffset.UTC);
-  }
-
-  @Override
-  public String getScope() {
-    return "issue.ProgrammeMembership";
-  }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/ProgrammeMembershipDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/ProgrammeMembershipDto.java
@@ -42,7 +42,7 @@ public record ProgrammeMembershipDto(
     @NotEmpty String tisId,
     @NotEmpty String programmeName,
     @NotNull LocalDate startDate,
-    @NotNull LocalDate endDate) implements CredentialDataDto {
+    @NotNull LocalDate endDate) implements CredentialDto {
 
   @Override
   public Instant getExpiration(Instant issuedAt) {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/TestCredentialDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/TestCredentialDto.java
@@ -37,7 +37,7 @@ import java.time.ZoneOffset;
 public record TestCredentialDto(
     @NotEmpty String givenName,
     @NotEmpty String familyName,
-    @NotNull LocalDate birthDate) implements CredentialDataDto {
+    @NotNull LocalDate birthDate) implements CredentialDto {
 
   @Override
   public Instant getExpiration(Instant issuedAt) {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/mapper/CredentialDataMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/mapper/CredentialDataMapper.java
@@ -1,0 +1,42 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants.ComponentModel;
+import uk.nhs.hee.tis.trainee.credentials.dto.ProgrammeMembershipCredentialDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.ProgrammeMembershipDataDto;
+
+/**
+ * A mapper to map between TIS Data and Credential Data.
+ */
+@Mapper(componentModel = ComponentModel.SPRING)
+public interface CredentialDataMapper {
+
+  /**
+   * Map a programme membership data DTO to the equivalent credential DTO.
+   *
+   * @param data The programme membership data to map.
+   * @return The mapped programme membership credential.
+   */
+  ProgrammeMembershipCredentialDto toCredential(ProgrammeMembershipDataDto data);
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayService.java
@@ -38,7 +38,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties;
-import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDataDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDto;
 
 /**
  * A service providing credential gateway functionality.
@@ -71,7 +71,7 @@ public class GatewayService {
    * @param state The client state.
    * @return The URI to issue the credential.
    */
-  public Optional<URI> getCredentialUri(CredentialDataDto dto, String state) {
+  public Optional<URI> getCredentialUri(CredentialDto dto, String state) {
     HttpEntity<MultiValueMap<String, String>> request = buildParRequest(dto, state);
 
     log.info("Sending PAR request.");
@@ -89,7 +89,7 @@ public class GatewayService {
    * @param state The client state.
    * @return The built request.
    */
-  private HttpEntity<MultiValueMap<String, String>> buildParRequest(CredentialDataDto dto,
+  private HttpEntity<MultiValueMap<String, String>> buildParRequest(CredentialDto dto,
       String state) {
     log.info("Building PAR request.");
     String idTokenHint = jwtService.generateToken(dto);

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/JwtService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/JwtService.java
@@ -32,7 +32,7 @@ import javax.crypto.SecretKey;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties.IssuingProperties.TokenProperties;
-import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDataDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDto;
 
 /**
  * A service providing JWT token functionality.
@@ -61,7 +61,7 @@ public class JwtService {
    * @param dto The credential data to include in the token claims.
    * @return The generated token as an encoded string.
    */
-  public String generateToken(CredentialDataDto dto) {
+  public String generateToken(CredentialDto dto) {
     log.info("Generating id_token_hint JWT.");
     Instant now = Instant.now();
     Map<String, Object> claimsMap = mapper.convertValue(dto, Map.class);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ application:
       token-endpoint: https://${application.gateway.host}/issuing/token
       token:
         audience: https://${application.gateway.host}/issuing
-        issuer: ${GATEWAY_TOKEN_ISSUER}
+        issuer: ${application.gateway.client-id}
         signing-key: ${GATEWAY_TOKEN_SIGNING_KEY}
       redirect-uri: ${GATEWAY_ISSUING_REDIRECT_URI}
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayServiceTest.java
@@ -45,10 +45,10 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties;
 import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties.IssuingProperties;
-import uk.nhs.hee.tis.trainee.credentials.dto.PlacementDto;
-import uk.nhs.hee.tis.trainee.credentials.dto.ProgrammeMembershipDto;
-import uk.nhs.hee.tis.trainee.credentials.dto.TestCredentialDto;
 import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.PlacementDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.ProgrammeMembershipCredentialDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.TestCredentialDto;
 import uk.nhs.hee.tis.trainee.credentials.service.GatewayService.ParResponse;
 
 class GatewayServiceTest {
@@ -161,7 +161,7 @@ class GatewayServiceTest {
 
   @Test
   void shouldIncludeProgrammeMembershipScopeInParRequest() {
-    ProgrammeMembershipDto dto = new ProgrammeMembershipDto("", "", LocalDate.MIN, LocalDate.MAX);
+    var dto = new ProgrammeMembershipCredentialDto("", LocalDate.MIN, LocalDate.MAX);
 
     var argumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
@@ -172,7 +172,7 @@ class GatewayServiceTest {
     var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
     MultiValueMap<String, String> requestBody = request.getBody();
     assertThat("Unexpected scope.", requestBody.get("scope"),
-        is(List.of(dto.getScope())));
+        is(List.of("issue.ProgrammeMembership")));
   }
 
   @Test
@@ -188,7 +188,7 @@ class GatewayServiceTest {
     var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
     MultiValueMap<String, String> requestBody = request.getBody();
     assertThat("Unexpected scope.", requestBody.get("scope"),
-        is(List.of(dto.getScope())));
+        is(List.of("issue.Placement")));
   }
 
   @Test
@@ -203,7 +203,7 @@ class GatewayServiceTest {
 
     var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
     MultiValueMap<String, String> requestBody = request.getBody();
-    assertThat("Unexpected scope.", requestBody.get("scope"), is(List.of(dto.getScope())));
+    assertThat("Unexpected scope.", requestBody.get("scope"), is(List.of("issue.TestCredential")));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayServiceTest.java
@@ -45,10 +45,10 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties;
 import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties.IssuingProperties;
-import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDataDto;
 import uk.nhs.hee.tis.trainee.credentials.dto.PlacementDto;
 import uk.nhs.hee.tis.trainee.credentials.dto.ProgrammeMembershipDto;
 import uk.nhs.hee.tis.trainee.credentials.dto.TestCredentialDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDto;
 import uk.nhs.hee.tis.trainee.credentials.service.GatewayService.ParResponse;
 
 class GatewayServiceTest {
@@ -80,7 +80,7 @@ class GatewayServiceTest {
 
   @Test
   void shouldIncludeAcceptHeaderInParRequest() {
-    CredentialDataDto dto = mock(CredentialDataDto.class);
+    CredentialDto dto = mock(CredentialDto.class);
 
     when(jwtService.generateToken(dto)).thenReturn("id_token_hint_value");
 
@@ -97,7 +97,7 @@ class GatewayServiceTest {
 
   @Test
   void shouldIncludeContentTypeHeaderInParRequest() {
-    CredentialDataDto dto = mock(CredentialDataDto.class);
+    CredentialDto dto = mock(CredentialDto.class);
 
     when(jwtService.generateToken(dto)).thenReturn("id_token_hint_value");
 
@@ -114,7 +114,7 @@ class GatewayServiceTest {
 
   @Test
   void shouldIncludeClientIdInParRequest() {
-    CredentialDataDto dto = mock(CredentialDataDto.class);
+    CredentialDto dto = mock(CredentialDto.class);
 
     var argumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
@@ -129,7 +129,7 @@ class GatewayServiceTest {
 
   @Test
   void shouldIncludeClientSecretInParRequest() {
-    CredentialDataDto dto = mock(CredentialDataDto.class);
+    CredentialDto dto = mock(CredentialDto.class);
 
     var argumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
@@ -145,7 +145,7 @@ class GatewayServiceTest {
 
   @Test
   void shouldIncludeRedirectUriInParRequest() {
-    CredentialDataDto dto = mock(CredentialDataDto.class);
+    CredentialDto dto = mock(CredentialDto.class);
 
     var argumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
@@ -208,7 +208,7 @@ class GatewayServiceTest {
 
   @Test
   void shouldIncludeStateInParRequest() {
-    CredentialDataDto dto = mock(CredentialDataDto.class);
+    CredentialDto dto = mock(CredentialDto.class);
 
     var argumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
@@ -223,7 +223,7 @@ class GatewayServiceTest {
 
   @Test
   void shouldIncludeGeneratedNonceInParRequest() {
-    CredentialDataDto dto = mock(CredentialDataDto.class);
+    CredentialDto dto = mock(CredentialDto.class);
 
     var argumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
@@ -238,7 +238,7 @@ class GatewayServiceTest {
 
   @Test
   void shouldIncludeIdTokenHintInParRequest() {
-    CredentialDataDto dto = mock(CredentialDataDto.class);
+    CredentialDto dto = mock(CredentialDto.class);
 
     when(jwtService.generateToken(dto)).thenReturn("id_token_hint_value");
 
@@ -256,7 +256,7 @@ class GatewayServiceTest {
 
   @Test
   void shouldReturnEmptyUriWhenParResponseCodeNotCreated() {
-    CredentialDataDto dto = mock(CredentialDataDto.class);
+    CredentialDto dto = mock(CredentialDto.class);
 
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), any(), eq(ParResponse.class))).thenReturn(
         ResponseEntity.notFound().build());
@@ -268,7 +268,7 @@ class GatewayServiceTest {
 
   @Test
   void shouldReturnEmptyUriWhenParResponseEmpty() {
-    CredentialDataDto dto = mock(CredentialDataDto.class);
+    CredentialDto dto = mock(CredentialDto.class);
 
     var response = ResponseEntity.status(HttpStatus.CREATED).body((ParResponse) null);
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), any(), eq(ParResponse.class))).thenReturn(
@@ -281,7 +281,7 @@ class GatewayServiceTest {
 
   @Test
   void shouldReturnUriWhenParResponseNotEmpty() {
-    CredentialDataDto dto = mock(CredentialDataDto.class);
+    CredentialDto dto = mock(CredentialDto.class);
 
     String requestUri = "a-new-request-uri";
     var response = ResponseEntity.status(HttpStatus.CREATED).body(new ParResponse(requestUri));

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayServiceTest.java
@@ -172,7 +172,7 @@ class GatewayServiceTest {
     var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
     MultiValueMap<String, String> requestBody = request.getBody();
     assertThat("Unexpected scope.", requestBody.get("scope"),
-        is(List.of("issue.ProgrammeMembership")));
+        is(List.of("issue.TrainingProgramme")));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/JwtServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/JwtServiceTest.java
@@ -45,10 +45,10 @@ import javax.crypto.SecretKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties.IssuingProperties.TokenProperties;
-import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDataDto;
 import uk.nhs.hee.tis.trainee.credentials.dto.PlacementDto;
 import uk.nhs.hee.tis.trainee.credentials.dto.ProgrammeMembershipDto;
 import uk.nhs.hee.tis.trainee.credentials.dto.TestCredentialDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDto;
 
 class JwtServiceTest {
 
@@ -92,7 +92,7 @@ class JwtServiceTest {
 
   @Test
   void shouldGenerateTokenWithDefaultClaims() {
-    record EmptyData() implements CredentialDataDto {
+    record EmptyData() implements CredentialDto {
 
       @Override
       public Instant getExpiration(Instant issuedAt) {

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/JwtServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/JwtServiceTest.java
@@ -45,10 +45,10 @@ import javax.crypto.SecretKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties.IssuingProperties.TokenProperties;
-import uk.nhs.hee.tis.trainee.credentials.dto.PlacementDto;
-import uk.nhs.hee.tis.trainee.credentials.dto.ProgrammeMembershipDto;
-import uk.nhs.hee.tis.trainee.credentials.dto.TestCredentialDto;
 import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.PlacementDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.ProgrammeMembershipCredentialDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.TestCredentialDto;
 
 class JwtServiceTest {
 
@@ -126,8 +126,7 @@ class JwtServiceTest {
 
   @Test
   void shouldGenerateTokenWithProgrammeMembershipClaims() {
-    ProgrammeMembershipDto dto = new ProgrammeMembershipDto(
-        "123", PROGRAMME_NAME, START_DATE, END_DATE);
+    var dto = new ProgrammeMembershipCredentialDto(PROGRAMME_NAME, START_DATE, END_DATE);
 
     String tokenString = service.generateToken(dto);
 
@@ -135,7 +134,6 @@ class JwtServiceTest {
     Claims tokenClaims = token.getBody();
 
     assertThat("Unexpected number of claims.", tokenClaims.size(), is(DEFAULT_CLAIM_COUNT + 3));
-    assertThat("Unexpected claim.", tokenClaims.get("tisId"), nullValue());
     assertThat("Unexpected programme name.", tokenClaims.get("programmeName"), is(PROGRAMME_NAME));
     assertThat("Unexpected programme start date.", tokenClaims.get("startDate"),
         is(START_DATE.toString()));

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/JwtServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/JwtServiceTest.java
@@ -134,10 +134,10 @@ class JwtServiceTest {
     Claims tokenClaims = token.getBody();
 
     assertThat("Unexpected number of claims.", tokenClaims.size(), is(DEFAULT_CLAIM_COUNT + 3));
-    assertThat("Unexpected programme name.", tokenClaims.get("programmeName"), is(PROGRAMME_NAME));
-    assertThat("Unexpected programme start date.", tokenClaims.get("startDate"),
+    assertThat("Unexpected programme name.", tokenClaims.get("TPR-Name"), is(PROGRAMME_NAME));
+    assertThat("Unexpected programme start date.", tokenClaims.get("TPR-ProgrammeStartDate"),
         is(START_DATE.toString()));
-    assertThat("Unexpected programme end date.", tokenClaims.get("endDate"),
+    assertThat("Unexpected programme end date.", tokenClaims.get("TPR-ProgrammeEndDate"),
         is(END_DATE.toString()));
 
     Instant issuedAt = tokenClaims.getIssuedAt().toInstant();


### PR DESCRIPTION
Update the programme membership credential's field names to match what is expected in the gateway schema.
Refactor the programme membership DTO in to separate "TIS data" and "credential data" DTOs, this allows easier and safer modification to the credential contents without affecting the acceptable DTO for our API.