### PR TITLE
fix: allow placement NPN to be missing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.4.1"
+version = "0.4.2"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/PlacementDataDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/PlacementDataDto.java
@@ -41,7 +41,7 @@ public record PlacementDataDto(
     @NotEmpty String tisId,
     @NotEmpty String specialty,
     @NotEmpty String grade,
-    @NotEmpty String nationalPostNumber,
+    String nationalPostNumber,
     @NotEmpty String employingBody,
     @NotEmpty String site,
     @NotNull LocalDate startDate,

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResourceTest.java
@@ -447,10 +447,10 @@ class IssueResourceTest {
   /**
    * Allow national post number to be missing from placement data.
    *
-   * This is a temporary relaxation of the normal rules until the field is populated in
+   * <p>This is a temporary relaxation of the normal rules until the field is populated in
    * tis-trainee-details.
    *
-   * @throws Exception
+   * <p>@throws Exception If the dataToSign was not valid JSON.
    */
   void shouldAcceptPlacementWhenNpnMissing() throws Exception {
     String signedData = SignatureTestUtil.removeFieldAndSignData(UNSIGNED_PLACEMENT, secretKey,

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResourceTest.java
@@ -397,8 +397,6 @@ class IssueResourceTest {
           specialty          |
           grade              | ''
           grade              |
-          nationalPostNumber | ''
-          nationalPostNumber |
           employingBody      | ''
           employingBody      |
           site               | ''
@@ -428,7 +426,6 @@ class IssueResourceTest {
       "tisId",
       "specialty",
       "grade",
-      "nationalPostNumber",
       "employingBody",
       "site",
       "startDate",
@@ -445,5 +442,25 @@ class IssueResourceTest {
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(service);
+  }
+
+  /**
+   * Allow national post number to be missing from placement data.
+   *
+   * This is a temporary relaxation of the normal rules until the field is populated in
+   * tis-trainee-details.
+   *
+   * @throws Exception
+   */
+  void shouldAcceptPlacementWhenNpnMissing() throws Exception {
+    String signedData = SignatureTestUtil.removeFieldAndSignData(UNSIGNED_PLACEMENT, secretKey,
+        "nationalPostNumber");
+
+    mockMvc.perform(
+            post("/api/issue/placement")
+                .content(signedData)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+
   }
 }


### PR DESCRIPTION
A temporary relaxation of the rules until we populate this field correctly in the trainee profile.

TIS21-4073