### PR TITLE
feat: POC for identity verification

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/VerifyResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/VerifyResource.java
@@ -1,0 +1,98 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.api;
+
+import io.jsonwebtoken.Claims;
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import uk.nhs.hee.tis.trainee.credentials.dto.IdentityDataDto;
+import uk.nhs.hee.tis.trainee.credentials.service.CacheService;
+import uk.nhs.hee.tis.trainee.credentials.service.GatewayService;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/verify")
+public class VerifyResource {
+
+  private final CacheService cacheService;
+  private final GatewayService gatewayService;
+
+  VerifyResource(CacheService cacheService, GatewayService gatewayService) {
+    this.cacheService = cacheService;
+    this.gatewayService = gatewayService;
+  }
+
+  @PostMapping("/identity")
+  ResponseEntity<String> verifyIdentity(
+      @Validated @RequestBody IdentityDataDto dto,
+      @RequestParam(required = false) String state) {
+
+    String cacheKey = cacheService.cacheIdentityData(dto);
+    URI identityVerificationUri = gatewayService.getIdentityVerificationUri(cacheKey, state);
+    return ResponseEntity
+        .status(HttpStatus.CREATED)
+        .location(identityVerificationUri)
+        .body(identityVerificationUri.toString());
+  }
+
+  @GetMapping("/identity/callback")
+  ResponseEntity<String> verifyIdentity(
+      @RequestHeader(HttpHeaders.AUTHORIZATION) String token,
+      @RequestParam String code,
+      @RequestParam String state) {
+    Claims claims = gatewayService.getVerificationTokenClaims(code, state);
+    String nonce = claims.get("nonce", String.class);
+    Optional<IdentityDataDto> optionalDto = cacheService.getCachedIdentityData(nonce);
+
+    if (optionalDto.isPresent()) {
+      String legalFirstName = claims.get("Identity.ID-LegalFirstName", String.class);
+      String legalSurname = claims.get("Identity.ID-LegalSurname", String.class);
+      LocalDate birthDate = LocalDate.parse(claims.get("Identity.ID-BirthDate", String.class));
+
+      IdentityDataDto dto = optionalDto.get();
+
+      if (dto.givenName().equals(legalFirstName) && dto.familyName().equals(legalSurname)
+          && dto.birthDate().equals(birthDate)) {
+        cacheService.cacheVerifiedIdentityJwt(token);
+        // TODO: forward back to the app.
+//        return ResponseEntity.status(HttpStatus.FOUND)
+//            .location(URI.create("http://local.tis-selfservice.com/identity-verified")).build();
+        return ResponseEntity.ok("Identity Verified.");
+      }
+    }
+
+    return ResponseEntity.badRequest().body("Unable to verify identity.");
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/GatewayProperties.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/GatewayProperties.java
@@ -34,7 +34,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record GatewayProperties(
     String clientId,
     String clientSecret,
-    IssuingProperties issuing) {
+    IssuingProperties issuing,
+    VerificationProperties verification) {
 
   /**
    * A representation of the gateway's issuing properties.
@@ -63,5 +64,12 @@ public record GatewayProperties(
     public record TokenProperties(String audience, String issuer, String signingKey) {
 
     }
+  }
+
+  public record VerificationProperties(
+      String identityEndpoint,
+      String tokenEndpoint,
+      String redirectUri) {
+
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/IdentityDataDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/IdentityDataDto.java
@@ -1,0 +1,28 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.dto;
+
+import java.time.LocalDate;
+
+public record IdentityDataDto(String givenName, String familyName, LocalDate birthDate) {
+
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/CacheService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/CacheService.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.service;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.trainee.credentials.dto.IdentityDataDto;
+
+@Service
+public class CacheService {
+
+  private final Map<String, IdentityDataDto> identityCache = new HashMap<>();
+  private final Map<String, Instant> verifiedIdentityJwts = new HashMap<>();
+
+  private final Map<String, String> codeVerifierCache = new HashMap<>();
+
+  public String cacheIdentityData(IdentityDataDto dto) {
+    String cacheKey = UUID.randomUUID().toString();
+    identityCache.put(cacheKey, dto);
+    return cacheKey;
+  }
+
+  public Optional<IdentityDataDto> getCachedIdentityData(String cacheKey) {
+    IdentityDataDto dto = identityCache.get(cacheKey);
+    return Optional.ofNullable(dto);
+  }
+
+  public void cacheVerifiedIdentityJwt(String jwt) {
+    verifiedIdentityJwts.put(jwt, Instant.now().plusSeconds(600));
+  }
+
+  public boolean hasVerifiedIdentity(String jwt) {
+    Instant now = Instant.now();
+    Instant expiry = verifiedIdentityJwts.getOrDefault(jwt, now);
+    return expiry.isAfter(now);
+  }
+
+  public void cacheCodeVerifier(String state, String codeVerifier) {
+    codeVerifierCache.put(state, codeVerifier);
+  }
+
+  public String getCachedCodeVerifier(String state) {
+    return codeVerifierCache.get(state);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,10 @@ application:
         issuer: ${application.gateway.client-id}
         signing-key: ${GATEWAY_TOKEN_SIGNING_KEY}
       redirect-uri: ${GATEWAY_ISSUING_REDIRECT_URI}
-
+    verification:
+      identity-endpoint: https://${application.gateway.host}/connect/authorize?client_id=${application.gateway.client-id}&response_type=code&redirect_uri=${application.gateway.verification.redirect-uri}&response_mode=query&scope=openid+Identity
+      token-endpoint: https://${application.gateway.host}/connect/token
+      redirect-uri: ${GATEWAY_VERIFICATION_REDIRECT_URI:https://jwt.ms} # http://local.tis-selfservice.com/credentials/api/verify/identity/callback}
   signature:
     secret-key: ${SIGNATURE_SECRET_KEY}
 


### PR DESCRIPTION
A user should be required to verify their identity, using a DSP credential, before a TSS credential is able to be issued. The general flow is designed as below, assuming no previous iteration with the credential service.

 1. The user requests to issue a TSS credential
 2. The issuance is rejected, with guidance to verify identity
 3. The user sends signed PersonalDetails data to `/api/verify/identity`
 4. The user is sent to the credential gateway to provide an identity
 5. The gateway returns the token code to `/api/verify/identity/callback`
 6. We request the full token from the gateway and extract the claims
 7. We compare the claims to the original PersonalDetails, if matching a "verified session" is cached.
 8. The user sends a new request to issue a TSS credential
 9. The issuance is allowed as a verified session is available

---

Update application.yml and GatewayProperties to add new properties for verification endpoints.

Create VerifyResource with endpoints for requesting an identity credential and then retrieving the associated token. The logic in this class would normally be held within a `VerificationService` class instead of directly in the controller.

Create a CacheService to cache the identity data, identity verification status and code verifiers that need to persist between requests. This should be replaced with a Redis backed cache, possibly a Redis backed HttpSession.

Create a VerifiedIdentityFilter which checks whether the user has verified their identity, requests to `/issue` endpoints will be blocked without prior verification.

TIS21-4108