### PR TITLE
feat: create endpoint to start id verification

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -31,6 +31,26 @@
         {
           "name": "SIGNATURE_SECRET_KEY",
           "valueFrom": "/tis/trainee/${environment}/signature/secret-key"
+        },
+        {
+          "name": "REDIS_HOST",
+          "valueFrom": "/tis/trainee/${environment}/redis/host"
+        },
+        {
+          "name": "REDIS_PORT",
+          "valueFrom": "/tis/trainee/${environment}/redis/port"
+        },
+        {
+          "name": "REDIS_SSL",
+          "valueFrom": "/tis/trainee/${environment}/redis/ssl"
+        },
+        {
+          "name": "REDIS_USER",
+          "valueFrom": "/tis/trainee/${environment}/redis/user"
+        },
+        {
+          "name": "REDIS_PASSWORD",
+          "valueFrom": "/tis/trainee/${environment}/redis/password"
         }
       ],
       "logConfiguration": {

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,16 @@ dependencies {
   implementation "io.jsonwebtoken:jjwt-api:$jjwtVersion"
   runtimeOnly "io.jsonwebtoken:jjwt-impl:$jjwtVersion"
   runtimeOnly "io.jsonwebtoken:jjwt-jackson:$jjwtVersion"
+
+  testImplementation "org.springframework.cloud:spring-cloud-starter-bootstrap"
+  testImplementation "com.playtika.testcontainers:embedded-redis:2.3.1"
+  testImplementation "org.testcontainers:junit-jupiter:1.17.6"
+}
+
+dependencyManagement {
+  imports {
+    mavenBom "org.springframework.cloud:spring-cloud-dependencies:2022.0.1"
+  }
 }
 
 checkstyle {

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.4.2"
+version = "0.5.0"
 
 configurations {
   compileOnly {

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 dependencies {
   // Spring Boot starters
   implementation "org.springframework.boot:spring-boot-starter-actuator"
+  implementation "org.springframework.boot:spring-boot-starter-data-redis"
   implementation "org.springframework.boot:spring-boot-starter-web"
   implementation "org.springframework.boot:spring-boot-starter-validation"
   testImplementation "org.springframework.boot:spring-boot-starter-test"

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/VerifyResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/VerifyResource.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.api;
+
+import java.net.URI;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import uk.nhs.hee.tis.trainee.credentials.dto.IdentityDataDto;
+import uk.nhs.hee.tis.trainee.credentials.service.VerificationService;
+
+/**
+ * API endpoints for verifying trainee digital credentials.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/verify")
+public class VerifyResource {
+
+  private final VerificationService service;
+
+  VerifyResource(VerificationService service) {
+    this.service = service;
+  }
+
+  @PostMapping("/identity")
+  ResponseEntity<String> verifyIdentity(
+      @RequestParam(required = false) String state,
+      @Validated @RequestBody IdentityDataDto dto) {
+    URI identityVerificationUri = service.startIdentityVerification(state, dto);
+    return ResponseEntity
+        .status(HttpStatus.CREATED)
+        .location(identityVerificationUri)
+        .body(identityVerificationUri.toString());
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/VerifyResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/VerifyResource.java
@@ -22,8 +22,8 @@
 package uk.nhs.hee.tis.trainee.credentials.api;
 
 import java.net.URI;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -52,10 +52,16 @@ public class VerifyResource {
   ResponseEntity<String> verifyIdentity(
       @RequestParam(required = false) String state,
       @Validated @RequestBody IdentityDataDto dto) {
-    URI identityVerificationUri = service.startIdentityVerification(state, dto);
-    return ResponseEntity
-        .status(HttpStatus.CREATED)
-        .location(identityVerificationUri)
-        .body(identityVerificationUri.toString());
+    log.info("Received request to start identity verification.");
+    Optional<URI> identityVerificationUri = service.startIdentityVerification(dto, state);
+
+    if (identityVerificationUri.isPresent()) {
+      log.info("Identity verification successfully started.");
+      URI uri = identityVerificationUri.get();
+      return ResponseEntity.created(uri).body(uri.toString());
+    } else {
+      log.error("Could not start identity verification.");
+      return ResponseEntity.internalServerError().build();
+    }
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/VerifyResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/VerifyResource.java
@@ -22,7 +22,6 @@
 package uk.nhs.hee.tis.trainee.credentials.api;
 
 import java.net.URI;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -53,15 +52,9 @@ public class VerifyResource {
       @RequestParam(required = false) String state,
       @Validated @RequestBody IdentityDataDto dto) {
     log.info("Received request to start identity verification.");
-    Optional<URI> identityVerificationUri = service.startIdentityVerification(dto, state);
+    URI uri = service.startIdentityVerification(dto, state);
 
-    if (identityVerificationUri.isPresent()) {
-      log.info("Identity verification successfully started.");
-      URI uri = identityVerificationUri.get();
-      return ResponseEntity.created(uri).body(uri.toString());
-    } else {
-      log.error("Could not start identity verification.");
-      return ResponseEntity.internalServerError().build();
-    }
+    log.info("Identity verification successfully started.");
+    return ResponseEntity.created(uri).body(uri.toString());
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/CacheConfiguration.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/CacheConfiguration.java
@@ -1,0 +1,101 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.config;
+
+import java.time.Duration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.cache.CacheKeyPrefix;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager.RedisCacheManagerBuilder;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+/**
+ * Configuration for caching behaviour.
+ */
+@Configuration
+@EnableCaching
+public class CacheConfiguration {
+
+  public static final String VERIFICATION_REQUEST_DATA = "verificationRequestCacheManager";
+  public static final String VERIFIED_SESSION_DATA = "verifiedSessionCacheManager";
+
+  private final CacheProperties properties;
+
+  CacheConfiguration(CacheProperties properties) {
+    this.properties = properties;
+  }
+
+  /**
+   * Create a default cache manager for anything not covered by the overrides.
+   *
+   * @param factory The Redis connection factory.
+   * @return The built cache manager.
+   */
+  @Primary
+  @Bean
+  public CacheManager defaultCacheManager(RedisConnectionFactory factory) {
+    return buildCacheManager(factory, Duration.ofSeconds(0));
+  }
+
+  /**
+   * Create a cache manager for caching of verification request data.
+   *
+   * @param factory The Redis connection factory.
+   * @return The built cache manager.
+   */
+  @Bean
+  public CacheManager verificationRequestCacheManager(RedisConnectionFactory factory) {
+    return buildCacheManager(factory, properties.timeToLive().verificationRequest());
+  }
+
+  /**
+   * Create a cache manager for verified session caching.
+   *
+   * @param factory The Redis connection factory.
+   * @return The built cache manager.
+   */
+  @Bean
+  public CacheManager verifiedSessionCacheManager(RedisConnectionFactory factory) {
+    return buildCacheManager(factory, properties.timeToLive().verifiedSession());
+  }
+
+  /**
+   * Build a cache manager using the given factory, with the given TTL.
+   *
+   * @param factory The Redis connection factory.
+   * @param ttl     The time-to-live to apply to the cache manager.
+   * @return The built cache manager.
+   */
+  private CacheManager buildCacheManager(RedisConnectionFactory factory, Duration ttl) {
+    RedisCacheConfiguration configuration = RedisCacheConfiguration.defaultCacheConfig()
+        .entryTtl(ttl)
+        .prefixCacheNameWith(properties.keyPrefix() + CacheKeyPrefix.SEPARATOR);
+
+    return RedisCacheManagerBuilder.fromConnectionFactory(factory)
+        .cacheDefaults(configuration)
+        .build();
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/CacheProperties.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/CacheProperties.java
@@ -1,0 +1,52 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.config;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.convert.DurationUnit;
+
+/**
+ * A representation of the application cache properties.
+ *
+ * @param keyPrefix  The cache key prefix.
+ * @param timeToLive The time-to-live properties.
+ */
+@ConfigurationProperties(prefix = "application.cache")
+public record CacheProperties(String keyPrefix, TimeToLiveProperties timeToLive) {
+
+  /**
+   * A representation of the application cache time-to-live properties.
+   *
+   * @param verificationRequest The time-to-live for verification request data.
+   * @param verifiedSession     The time-to-live for verified session data.
+   */
+  public record TimeToLiveProperties(
+      @DurationUnit(ChronoUnit.SECONDS)
+      Duration verificationRequest,
+
+      @DurationUnit(ChronoUnit.SECONDS)
+      Duration verifiedSession) {
+
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/GatewayProperties.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/GatewayProperties.java
@@ -34,14 +34,15 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record GatewayProperties(
     String clientId,
     String clientSecret,
-    IssuingProperties issuing) {
+    IssuingProperties issuing,
+    VerificationProperties verification) {
 
   /**
    * A representation of the gateway's issuing properties.
    *
    * @param parEndpoint       The gateway's PAR endpoint URI.
-   * @param authorizeEndpoint The gateway's authorize endpoint URI.
-   * @param tokenEndpoint     The gateway's token endpoint URI.
+   * @param authorizeEndpoint The gateway's issue authorize endpoint URI.
+   * @param tokenEndpoint     The gateway's issue token endpoint URI.
    * @param token             The issuing token child properties.
    * @param redirectUri       The URI to redirect to after issuing a credential.
    */
@@ -63,5 +64,15 @@ public record GatewayProperties(
     public record TokenProperties(String audience, String issuer, String signingKey) {
 
     }
+  }
+
+  /**
+   * A representation of the gateway verification properties.
+   *
+   * @param authorizeEndpoint The gateway's connect authorize endpoint URI.
+   */
+  @ConfigurationProperties(prefix = "application.gateway.verification")
+  public record VerificationProperties(String authorizeEndpoint) {
+
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/IdentityDataDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/IdentityDataDto.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.tis.trainee.credentials.dto;
 
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.time.LocalDate;
 
@@ -31,7 +33,9 @@ import java.time.LocalDate;
  * @param familyName The user's family name.
  * @param birthDate  The user's birthdate.
  */
-public record IdentityDataDto(String givenName, String familyName, LocalDate birthDate) implements
-    Serializable {
+public record IdentityDataDto(
+    @NotEmpty String givenName,
+    @NotEmpty String familyName,
+    @NotNull LocalDate birthDate) implements Serializable {
 
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/IdentityDataDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/IdentityDataDto.java
@@ -1,0 +1,37 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.dto;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+
+/**
+ * A DTO representing identity data.
+ *
+ * @param givenName  The user's given name.
+ * @param familyName The user's family name.
+ * @param birthDate  The user's birthdate.
+ */
+public record IdentityDataDto(String givenName, String familyName, LocalDate birthDate) implements
+    Serializable {
+
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/filter/FilterConfiguration.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/filter/FilterConfiguration.java
@@ -44,7 +44,7 @@ public class FilterConfiguration {
     FilterRegistrationBean<SignedDataFilter> registrationBean = new FilterRegistrationBean<>();
 
     registrationBean.setFilter(filter);
-    registrationBean.addUrlPatterns("/api/issue/*");
+    registrationBean.addUrlPatterns("/api/issue/*", "/api/verify/*");
     registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE);
 
     return registrationBean;

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegate.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegate.java
@@ -88,7 +88,7 @@ class CachingDelegate {
    */
   @Cacheable(cacheNames = IDENTITY_DATA, cacheManager = VERIFICATION_REQUEST_DATA)
   @CacheEvict(IDENTITY_DATA)
-  public Optional<IdentityDataDto> getIdentityData(String key) {
+  public Optional<IdentityDataDto> getIdentityData(UUID key) {
     return Optional.empty();
   }
 
@@ -124,18 +124,17 @@ class CachingDelegate {
    * @return The cached session id.
    */
   @CachePut(cacheNames = SESSION_IDENTIFIER, cacheManager = VERIFIED_SESSION_DATA, key = "#key")
-  public UUID cacheVerifiedSession(UUID key, String verifiedSessionId) {
-    return key;
+  public String cacheVerifiedSession(UUID key, String verifiedSessionId) {
+    return verifiedSessionId;
   }
 
   /**
-   * Get the verified session associated with the given key, any cached value will be removed.
+   * Get the verified session associated with the given key.
    *
    * @param key The cache key.
    * @return The cached session id, or an empty optional if not found.
    */
   @Cacheable(cacheNames = SESSION_IDENTIFIER, cacheManager = VERIFIED_SESSION_DATA)
-  @CacheEvict(SESSION_IDENTIFIER)
   public Optional<String> getVerifiedSession(UUID key) {
     return Optional.empty();
   }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegate.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegate.java
@@ -1,0 +1,142 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.service;
+
+import static uk.nhs.hee.tis.trainee.credentials.config.CacheConfiguration.VERIFICATION_REQUEST_DATA;
+import static uk.nhs.hee.tis.trainee.credentials.config.CacheConfiguration.VERIFIED_SESSION_DATA;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+import uk.nhs.hee.tis.trainee.credentials.dto.IdentityDataDto;
+
+/**
+ * Caching annotations do not work within the same class, this delegate provides a lightweight
+ * caching interface for services.
+ */
+@Component
+class CachingDelegate {
+
+  private static final String CLIENT_STATE = "ClientState";
+  private static final String CODE_VERIFIER = "CodeVerifier";
+  public static final String IDENTITY_DATA = "IdentityData";
+  public static final String SESSION_IDENTIFIER = "SessionIdentifier";
+
+  /**
+   * Cache a PKCE code verifier for later retrieval.
+   *
+   * @param key          The cache key.
+   * @param codeVerifier The code verifier to cache.
+   * @return The cached code verifier.
+   */
+  @CachePut(cacheNames = CODE_VERIFIER, cacheManager = VERIFICATION_REQUEST_DATA, key = "#key")
+  public String cacheCodeVerifier(UUID key, String codeVerifier) {
+    return codeVerifier;
+  }
+
+  /**
+   * Get the PKCE code verifier associated with the given key, any cached value will be removed.
+   *
+   * @param key The cache key.
+   * @return The cached code verifier, or an empty optional if not found.
+   */
+  @Cacheable(cacheNames = CODE_VERIFIER, cacheManager = VERIFICATION_REQUEST_DATA)
+  @CacheEvict(CODE_VERIFIER)
+  public Optional<String> getCodeVerifier(UUID key) {
+    return Optional.empty();
+  }
+
+  /**
+   * Cache an identity data dto for later retrieval.
+   *
+   * @param key The cache key.
+   * @param dto The identity data to cache.
+   * @return The cached identity data.
+   */
+  @CachePut(cacheNames = IDENTITY_DATA, cacheManager = VERIFICATION_REQUEST_DATA, key = "#key")
+  public IdentityDataDto cacheIdentityData(UUID key, IdentityDataDto dto) {
+    return dto;
+  }
+
+  /**
+   * Get the identity data associated with the given key, any cached value will be removed.
+   *
+   * @param key The cache key.
+   * @return The cached identity data, or an empty optional if not found.
+   */
+  @Cacheable(cacheNames = IDENTITY_DATA, cacheManager = VERIFICATION_REQUEST_DATA)
+  @CacheEvict(IDENTITY_DATA)
+  public Optional<IdentityDataDto> getIdentityData(String key) {
+    return Optional.empty();
+  }
+
+  /**
+   * Cache a client state for later retrieval.
+   *
+   * @param key         The cache key.
+   * @param clientState The client state to cache.
+   * @return The cached client state.
+   */
+  @CachePut(cacheNames = CLIENT_STATE, cacheManager = VERIFICATION_REQUEST_DATA, key = "#key")
+  public String cacheClientState(UUID key, String clientState) {
+    return clientState;
+  }
+
+  /**
+   * Get the client state associated with the given key, any cached value will be removed.
+   *
+   * @param key The cache key.
+   * @return The cached client state, or an empty optional if not found.
+   */
+  @Cacheable(cacheNames = CLIENT_STATE, cacheManager = VERIFICATION_REQUEST_DATA)
+  @CacheEvict(CLIENT_STATE)
+  public Optional<String> getClientState(UUID key) {
+    return Optional.empty();
+  }
+
+  /**
+   * Cache a verified session for later retrieval.
+   *
+   * @param key               The cache key.
+   * @param verifiedSessionId The ID of the verified session to cache.
+   * @return The cached session id.
+   */
+  @CachePut(cacheNames = SESSION_IDENTIFIER, cacheManager = VERIFIED_SESSION_DATA, key = "#key")
+  public UUID cacheVerifiedSession(UUID key, String verifiedSessionId) {
+    return key;
+  }
+
+  /**
+   * Get the verified session associated with the given key, any cached value will be removed.
+   *
+   * @param key The cache key.
+   * @return The cached session id, or an empty optional if not found.
+   */
+  @Cacheable(cacheNames = SESSION_IDENTIFIER, cacheManager = VERIFIED_SESSION_DATA)
+  @CacheEvict(SESSION_IDENTIFIER)
+  public Optional<String> getVerifiedSession(UUID key) {
+    return Optional.empty();
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationService.java
@@ -24,7 +24,6 @@ package uk.nhs.hee.tis.trainee.credentials.service;
 import java.net.URI;
 import java.security.SecureRandom;
 import java.util.Base64;
-import java.util.Optional;
 import java.util.UUID;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.springframework.lang.Nullable;
@@ -61,7 +60,7 @@ public class VerificationService {
    * @param clientState The state sent by client when making the request to start verification.
    * @return A URI to a credential gateway prompt for an identity credential.
    */
-  public Optional<URI> startIdentityVerification(IdentityDataDto dto,
+  public URI startIdentityVerification(IdentityDataDto dto,
       @Nullable String clientState) {
     // Cache the provided identity data against the nonce.
     UUID nonce = UUID.randomUUID();
@@ -77,7 +76,7 @@ public class VerificationService {
     String codeChallenge = generateCodeChallenge(codeVerifier);
 
     // Build and return the URI at which the user can provide an identity credential.
-    URI uri = UriComponentsBuilder.fromUriString(properties.authorizeEndpoint())
+    return UriComponentsBuilder.fromUriString(properties.authorizeEndpoint())
         .queryParam("nonce", nonce)
         .queryParam("state", internalState)
         .queryParam("code_challenge_method", "S256")
@@ -85,8 +84,6 @@ public class VerificationService {
         .queryParam("scope", "openid+Identity")
         .build()
         .toUri();
-
-    return Optional.of(uri);
   }
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationService.java
@@ -1,0 +1,110 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.service;
+
+import java.net.URI;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.UUID;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties.VerificationProperties;
+import uk.nhs.hee.tis.trainee.credentials.dto.IdentityDataDto;
+
+/**
+ * A service providing credential verification functionality.
+ */
+@Service
+public class VerificationService {
+
+  private final CachingDelegate cachingDelegate;
+  private final VerificationProperties properties;
+
+  /**
+   * Create a service providing credential verification functionality.
+   *
+   * @param cachingDelegate The caching delegate for caching data between requests.
+   * @param properties      The application's gateway verification configuration.
+   */
+  VerificationService(CachingDelegate cachingDelegate, VerificationProperties properties) {
+    this.cachingDelegate = cachingDelegate;
+    this.properties = properties;
+  }
+
+  /**
+   * Start the identity credential verification process, the result will direct the user to provide
+   * an identity credential using the credential gateway.
+   *
+   * @param clientState The state sent by client when making the request to start verification.
+   * @param dto         The user's identity data.
+   * @return A URI to a credential gateway prompt for an identity credential.
+   */
+  public URI startIdentityVerification(@Nullable String clientState, IdentityDataDto dto) {
+    // Cache the provided identity data against the nonce.
+    UUID nonce = UUID.randomUUID();
+    cachingDelegate.cacheIdentityData(nonce, dto);
+
+    // Generate new state for the internal request/callback and cache the client state.
+    UUID internalState = UUID.randomUUID();
+    cachingDelegate.cacheClientState(internalState, clientState);
+
+    // Generate and cache the code verifier against the state.
+    String codeVerifier = generateCodeVerifier();
+    cachingDelegate.cacheCodeVerifier(internalState, codeVerifier);
+    String codeChallenge = generateCodeChallenge(codeVerifier);
+
+    // Build and return the URI at which the user can provide an identity credential.
+    return UriComponentsBuilder.fromUriString(properties.authorizeEndpoint())
+        .queryParam("nonce", nonce)
+        .queryParam("state", internalState)
+        .queryParam("code_challenge_method", "S256")
+        .queryParam("code_challenge", codeChallenge)
+        .queryParam("scope", "openid+Identity")
+        .build()
+        .toUri();
+  }
+
+  /**
+   * Generate a random PKCE code verifier.
+   *
+   * @return The generated code verifier.
+   */
+  private String generateCodeVerifier() {
+    SecureRandom secureRandom = new SecureRandom();
+    byte[] codeVerifier = new byte[32];
+    secureRandom.nextBytes(codeVerifier);
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(codeVerifier);
+  }
+
+  /**
+   * Generate a code challenge from the code verifier.
+   *
+   * @param codeVerifier The code verifier to generate a challenge from.
+   * @return The generated code challenge.
+   */
+  private String generateCodeChallenge(String codeVerifier) {
+    byte[] codeChallenge = DigestUtils.sha256(codeVerifier);
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(codeChallenge);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,11 @@ server:
     context-path: /credentials
 
 application:
+  cache:
+    key-prefix: Credentials
+    time-to-live:
+      verification-request: ${REDIS_TTL_VERIFICATION_REQUEST:300}
+      verified-session: ${REDIS_TTL_VERIFIED_SESSION:600}
   gateway:
     host: ${GATEWAY_HOST}
     client-id: ${GATEWAY_CLIENT_ID}
@@ -17,10 +22,21 @@ application:
         issuer: ${application.gateway.client-id}
         signing-key: ${GATEWAY_TOKEN_SIGNING_KEY}
       redirect-uri: ${GATEWAY_ISSUING_REDIRECT_URI}
-
+    verification:
+      authorize-endpoint: https://${application.gateway.host}/connect/authorize?client_id=${application.gateway.client-id}&response_type=code&redirect_uri=${application.gateway.verification.redirect-uri}&response_mode=query
+      redirect-uri: ${GATEWAY_VERIFICATION_REDIRECT_URI:https://jwt.ms}
   signature:
     secret-key: ${SIGNATURE_SECRET_KEY}
 
 sentry:
   dsn: ${SENTRY_DSN:}
   environment: ${SENTRY_ENVIRONMENT:}
+
+spring:
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      ssl: ${REDIS_SSL:false}
+      user: ${REDIS_USER:default}
+      password: ${REDIS_PASSWORD:password}

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResourceTest.java
@@ -37,6 +37,7 @@ import java.net.URI;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Optional;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -56,11 +57,12 @@ import uk.nhs.hee.tis.trainee.credentials.SignatureTestUtil;
 import uk.nhs.hee.tis.trainee.credentials.dto.PlacementCredentialDto;
 import uk.nhs.hee.tis.trainee.credentials.dto.ProgrammeMembershipCredentialDto;
 import uk.nhs.hee.tis.trainee.credentials.dto.TestCredentialDto;
+import uk.nhs.hee.tis.trainee.credentials.filter.FilterConfiguration;
 import uk.nhs.hee.tis.trainee.credentials.mapper.CredentialDataMapper;
 import uk.nhs.hee.tis.trainee.credentials.service.GatewayService;
 
 @WebMvcTest(IssueResource.class)
-@ComponentScan(basePackageClasses = CredentialDataMapper.class)
+@ComponentScan(basePackageClasses = {CredentialDataMapper.class, FilterConfiguration.class})
 class IssueResourceTest {
 
   private static final String UNSIGNED_DATA = """
@@ -452,6 +454,8 @@ class IssueResourceTest {
    *
    * <p>@throws Exception If the dataToSign was not valid JSON.
    */
+  @Test
+  @Disabled("Disabled due to issues with the data, see above comment.")
   void shouldAcceptPlacementWhenNpnMissing() throws Exception {
     String signedData = SignatureTestUtil.removeFieldAndSignData(UNSIGNED_PLACEMENT, secretKey,
         "nationalPostNumber");
@@ -461,6 +465,5 @@ class IssueResourceTest {
                 .content(signedData)
                 .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk());
-
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/api/VerifyResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/api/VerifyResourceTest.java
@@ -1,0 +1,220 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.api;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.net.URI;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.nhs.hee.tis.trainee.credentials.SignatureTestUtil;
+import uk.nhs.hee.tis.trainee.credentials.dto.IdentityDataDto;
+import uk.nhs.hee.tis.trainee.credentials.filter.FilterConfiguration;
+import uk.nhs.hee.tis.trainee.credentials.service.VerificationService;
+
+@WebMvcTest(VerifyResource.class)
+@ComponentScan(basePackageClasses = FilterConfiguration.class)
+class VerifyResourceTest {
+
+  private static final String UNSIGNED_IDENTITY_DATA = """
+      {
+            "givenName": "Anthony",
+            "familyName": "Gilliam",
+            "birthDate": "1991-11-11",
+            "signature": {
+              "signedAt": "%s",
+              "validUntil": "%s"
+            }
+          }
+      """.formatted(Instant.MIN, Instant.MAX);
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private VerificationService service;
+
+  @MockBean
+  private RestTemplateBuilder restTemplateBuilder;
+
+  @Value("${application.signature.secret-key}")
+  private String secretKey;
+
+  @Test
+  void shouldForbidUnsignedVerifyIdentityRequests() throws Exception {
+    mockMvc.perform(
+            post("/api/verify/identity")
+                .content(UNSIGNED_IDENTITY_DATA)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void shouldReturnErrorWhenStartIdentityVerificationFails() throws Exception {
+    String signedData = SignatureTestUtil.signData(UNSIGNED_IDENTITY_DATA, secretKey);
+
+    when(service.startIdentityVerification(any(), any())).thenReturn(Optional.empty());
+
+    mockMvc.perform(
+            post("/api/verify/identity")
+                .content(signedData)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isInternalServerError());
+  }
+
+  @Test
+  void shouldReturnCreatedWhenCredentialUriAvailable()
+      throws Exception {
+    String signedData = SignatureTestUtil.signData(UNSIGNED_IDENTITY_DATA, secretKey);
+
+    String uriString = "the-uri";
+    URI uri = URI.create(uriString);
+    when(service.startIdentityVerification(any(IdentityDataDto.class), any())).thenReturn(
+        Optional.of(uri));
+
+    mockMvc.perform(
+            post("/api/verify/identity")
+                .content(signedData)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isCreated())
+        .andExpect(header().string(HttpHeaders.LOCATION, uriString))
+        .andExpect(content().string(uriString));
+  }
+
+  @Test
+  void shouldPassStateDownstreamWhenStateGiven() throws Exception {
+    String signedData = SignatureTestUtil.signData(UNSIGNED_IDENTITY_DATA, secretKey);
+
+    mockMvc.perform(
+        post("/api/verify/identity")
+            .queryParam("state", "some-state-value")
+            .content(signedData)
+            .contentType(MediaType.APPLICATION_JSON));
+
+    ArgumentCaptor<String> stateCaptor = ArgumentCaptor.forClass(String.class);
+    verify(service).startIdentityVerification(any(IdentityDataDto.class), stateCaptor.capture());
+
+    String state = stateCaptor.getValue();
+    assertThat("Unexpected state.", state, is("some-state-value"));
+  }
+
+  @Test
+  void shouldNotPassStateDownstreamWhenNoStateGiven() throws Exception {
+    String signedData = SignatureTestUtil.signData(UNSIGNED_IDENTITY_DATA, secretKey);
+
+    mockMvc.perform(
+        post("/api/verify/identity")
+            .content(signedData)
+            .contentType(MediaType.APPLICATION_JSON));
+
+    ArgumentCaptor<String> stateCaptor = ArgumentCaptor.forClass(String.class);
+    verify(service).startIdentityVerification(any(IdentityDataDto.class), stateCaptor.capture());
+
+    String state = stateCaptor.getValue();
+    assertThat("Unexpected state.", state, nullValue());
+  }
+
+  @Test
+  void shouldUseIdentityDataDtoFromRequestBody() throws Exception {
+    String signedData = SignatureTestUtil.signData(UNSIGNED_IDENTITY_DATA, secretKey);
+
+    mockMvc.perform(
+        post("/api/verify/identity")
+            .content(signedData)
+            .contentType(MediaType.APPLICATION_JSON));
+
+    ArgumentCaptor<IdentityDataDto> dtoCaptor = ArgumentCaptor.forClass(IdentityDataDto.class);
+    verify(service).startIdentityVerification(dtoCaptor.capture(), any());
+
+    IdentityDataDto dto = dtoCaptor.getValue();
+    assertThat("Unexpected given name.", dto.givenName(), is("Anthony"));
+    assertThat("Unexpected family name.", dto.familyName(), is("Gilliam"));
+    assertThat("Unexpected birth date.", dto.birthDate(), is(LocalDate.of(1991, 11, 11)));
+  }
+
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', textBlock = """
+          givenName  | ''
+          givenName  |
+          familyName | ''
+          familyName |
+          birthDate  | ''
+          birthDate  |
+      """)
+  void shouldRejectIdentityDataWhenPropertiesInvalid(String fieldName, String fieldValue)
+      throws Exception {
+    String signedData = SignatureTestUtil.overwriteFieldAndSignData(UNSIGNED_IDENTITY_DATA,
+        secretKey, fieldName, fieldValue);
+
+    mockMvc.perform(
+            post("/api/verify/identity")
+                .content(signedData)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "givenName",
+      "familyName",
+      "birthDate"
+  })
+  void shouldRejectIdentityDataWhenPropertiesMissing(String fieldName) throws Exception {
+    String signedData = SignatureTestUtil.removeFieldAndSignData(UNSIGNED_IDENTITY_DATA, secretKey,
+        fieldName);
+
+    mockMvc.perform(
+            post("/api/verify/identity")
+                .content(signedData)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(service);
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/filter/FilterConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/filter/FilterConfigurationTest.java
@@ -70,7 +70,16 @@ class FilterConfigurationTest {
     var registrationBean = configuration.registerSignedDataFilter(filter);
 
     Collection<String> urlPatterns = registrationBean.getUrlPatterns();
-    assertThat("Unexpected filter pattern count.", urlPatterns.size(), is(1));
     assertThat("Unexpected filter patterns.", urlPatterns, hasItem("/api/issue/*"));
+  }
+
+  @Test
+  void shouldRegisterSignedDataFilterOnVerifyApiEndpoints() {
+    SignedDataFilter filter = new SignedDataFilter(new ObjectMapper(), SIGNATURE_SECRET_KEY);
+
+    var registrationBean = configuration.registerSignedDataFilter(filter);
+
+    Collection<String> urlPatterns = registrationBean.getUrlPatterns();
+    assertThat("Unexpected filter patterns.", urlPatterns, hasItem("/api/verify/*"));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegateIntegrationTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegateIntegrationTest.java
@@ -1,0 +1,215 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.hee.tis.trainee.credentials.dto.IdentityDataDto;
+
+@SpringBootTest
+@ActiveProfiles("redis")
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+@Testcontainers(disabledWithoutDocker = true)
+class CachingDelegateIntegrationTest {
+
+  @Autowired
+  CachingDelegate delegate;
+
+  @Test
+  void shouldReturnEmptyClientStateWhenNotCached() {
+    UUID key = UUID.randomUUID();
+
+    Optional<String> cachedOptional = delegate.getClientState(key);
+    assertThat("Unexpected cached value.", cachedOptional, is(Optional.empty()));
+  }
+
+  @Test
+  void shouldReturnCachedClientStateAfterCaching() {
+    UUID key = UUID.randomUUID();
+
+    String clientState = "clientState1";
+    String cachedString = delegate.cacheClientState(key, clientState);
+    assertThat("Unexpected cached value.", cachedString, is(clientState));
+  }
+
+  @Test
+  void shouldGetCachedClientStateWhenCached() {
+    UUID key = UUID.randomUUID();
+
+    String clientState = "clientState1";
+    delegate.cacheClientState(key, clientState);
+
+    Optional<String> cachedOptional = delegate.getClientState(key);
+    assertThat("Unexpected cached value.", cachedOptional, is(Optional.of(clientState)));
+  }
+
+  @Test
+  void shouldRemoveClientStateWhenRetrieved() {
+    UUID key = UUID.randomUUID();
+
+    String clientState = "clientState1";
+    delegate.cacheClientState(key, clientState);
+
+    // Ignore this result, the cached value should be evicted.
+    delegate.getClientState(key);
+
+    Optional<String> cachedOptional = delegate.getClientState(key);
+    assertThat("Unexpected cached value.", cachedOptional, is(Optional.empty()));
+  }
+
+  @Test
+  void shouldReturnEmptyCodeVerifierWhenNotCached() {
+    UUID key = UUID.randomUUID();
+
+    Optional<String> cachedOptional = delegate.getCodeVerifier(key);
+    assertThat("Unexpected cached value.", cachedOptional, is(Optional.empty()));
+  }
+
+  @Test
+  void shouldReturnCachedCodeVerifierAfterCaching() {
+    UUID key = UUID.randomUUID();
+
+    String codeVerifier = "codeVerifier1";
+    String cachedString = delegate.cacheCodeVerifier(key, codeVerifier);
+    assertThat("Unexpected cached value.", cachedString, is(codeVerifier));
+  }
+
+  @Test
+  void shouldGetCachedCodeVerifierWhenCached() {
+    UUID key = UUID.randomUUID();
+
+    String codeVerifier = "codeVerifier1";
+    delegate.cacheCodeVerifier(key, codeVerifier);
+
+    Optional<String> cachedOptional = delegate.getCodeVerifier(key);
+    assertThat("Unexpected cached value.", cachedOptional, is(Optional.of(codeVerifier)));
+  }
+
+  @Test
+  void shouldRemoveCodeVerifierWhenRetrieved() {
+    UUID key = UUID.randomUUID();
+
+    String codeVerifier = "codeVerifier1";
+    delegate.cacheCodeVerifier(key, codeVerifier);
+
+    // Ignore this result, the cached value should be evicted.
+    delegate.getCodeVerifier(key);
+
+    Optional<String> cachedOptional = delegate.getCodeVerifier(key);
+    assertThat("Unexpected cached value.", cachedOptional, is(Optional.empty()));
+  }
+
+  @Test
+  void shouldReturnEmptyIdentityDataWhenNotCached() {
+    UUID key = UUID.randomUUID();
+
+    Optional<IdentityDataDto> cachedOptional = delegate.getIdentityData(key);
+    assertThat("Unexpected cached value.", cachedOptional, is(Optional.empty()));
+  }
+
+  @Test
+  void shouldReturnCachedIdentityDataAfterCaching() {
+    UUID key = UUID.randomUUID();
+
+    IdentityDataDto identityData = new IdentityDataDto("Anthony", "Gilliam", LocalDate.now());
+    IdentityDataDto cachedDto = delegate.cacheIdentityData(key, identityData);
+    assertThat("Unexpected cached value.", cachedDto, is(identityData));
+  }
+
+  @Test
+  void shouldGetCachedIdentityDataWhenCached() {
+    UUID key = UUID.randomUUID();
+
+    IdentityDataDto identityData = new IdentityDataDto("Anthony", "Gilliam", LocalDate.now());
+    delegate.cacheIdentityData(key, identityData);
+
+    Optional<IdentityDataDto> cachedOptional = delegate.getIdentityData(key);
+    assertThat("Unexpected cached value.", cachedOptional, is(Optional.of(identityData)));
+  }
+
+  @Test
+  void shouldRemoveIdentityDataWhenRetrieved() {
+    UUID key = UUID.randomUUID();
+
+    IdentityDataDto identityData = new IdentityDataDto("Anthony", "Gilliam", LocalDate.now());
+    delegate.cacheIdentityData(key, identityData);
+
+    // Ignore this result, the cached value should be evicted.
+    delegate.getIdentityData(key);
+
+    Optional<IdentityDataDto> cachedOptional = delegate.getIdentityData(key);
+    assertThat("Unexpected cached value.", cachedOptional, is(Optional.empty()));
+  }
+
+  @Test
+  void shouldReturnEmptyVerifiedSessionWhenNotCached() {
+    UUID key = UUID.randomUUID();
+
+    Optional<String> cachedOptional = delegate.getVerifiedSession(key);
+    assertThat("Unexpected cached value.", cachedOptional, is(Optional.empty()));
+  }
+
+  @Test
+  void shouldReturnCachedVerifiedSessionAfterCaching() {
+    UUID key = UUID.randomUUID();
+
+    String verifiedSession = "verifiedSession1";
+    String cachedString = delegate.cacheVerifiedSession(key, verifiedSession);
+    assertThat("Unexpected cached value.", cachedString, is(verifiedSession));
+  }
+
+  @Test
+  void shouldGetCachedVerifiedSessionWhenCached() {
+    UUID key = UUID.randomUUID();
+
+    String verifiedSession = "verifiedSession1";
+    delegate.cacheVerifiedSession(key, verifiedSession);
+
+    Optional<String> cachedOptional = delegate.getVerifiedSession(key);
+    assertThat("Unexpected cached value.", cachedOptional, is(Optional.of(verifiedSession)));
+  }
+
+  @Test
+  void shouldNotRemoveVerifiedSessionWhenRetrieved() {
+    UUID key = UUID.randomUUID();
+
+    String verifiedSession = "verifiedSession1";
+    delegate.cacheVerifiedSession(key, verifiedSession);
+
+    // Ignore this result, the cached value should be evicted.
+    delegate.getVerifiedSession(key);
+
+    Optional<String> cachedOptional = delegate.getVerifiedSession(key);
+    assertThat("Unexpected cached value.", cachedOptional, is(Optional.of(verifiedSession)));
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegateIntegrationTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegateIntegrationTest.java
@@ -30,15 +30,12 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import uk.nhs.hee.tis.trainee.credentials.dto.IdentityDataDto;
 
 @SpringBootTest
 @ActiveProfiles("redis")
-@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 @Testcontainers(disabledWithoutDocker = true)
 class CachingDelegateIntegrationTest {
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegateTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegateTest.java
@@ -1,0 +1,91 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.nhs.hee.tis.trainee.credentials.dto.IdentityDataDto;
+
+class CachingDelegateTest {
+
+  private CachingDelegate delegate;
+
+  @BeforeEach
+  void setUp() {
+    delegate = new CachingDelegate();
+  }
+
+  @Test
+  void shouldReturnCachedClientState() {
+    String clientState = delegate.cacheClientState(UUID.randomUUID(), "clientState1");
+    assertThat("Unexpected client state.", clientState, is("clientState1"));
+  }
+
+  @Test
+  void shouldGetEmptyClientState() {
+    Optional<String> clientState = delegate.getClientState(UUID.randomUUID());
+    assertThat("Unexpected client state.", clientState, is(Optional.empty()));
+  }
+
+  @Test
+  void shouldReturnCachedCodeVerifier() {
+    String codeVerifier = delegate.cacheCodeVerifier(UUID.randomUUID(), "codeVerifier1");
+    assertThat("Unexpected code verifier.", codeVerifier, is("codeVerifier1"));
+  }
+
+  @Test
+  void shouldGetEmptyCodeVerifier() {
+    Optional<String> codeVerifier = delegate.getCodeVerifier(UUID.randomUUID());
+    assertThat("Unexpected code verifier.", codeVerifier, is(Optional.empty()));
+  }
+
+  @Test
+  void shouldReturnCachedIdentityData() {
+    IdentityDataDto identityData = new IdentityDataDto("Anthony", "Gilliam", LocalDate.now());
+    IdentityDataDto returnValue = delegate.cacheIdentityData(UUID.randomUUID(), identityData);
+    assertThat("Unexpected identity data.", returnValue, is(identityData));
+  }
+
+  @Test
+  void shouldGetEmptyIdentityData() {
+    Optional<IdentityDataDto> identityData = delegate.getIdentityData(UUID.randomUUID());
+    assertThat("Unexpected identity data.", identityData, is(Optional.empty()));
+  }
+
+  @Test
+  void shouldReturnCachedVerifiedSession() {
+    String verifiedSession = delegate.cacheVerifiedSession(UUID.randomUUID(), "verifiedSession1");
+    assertThat("Unexpected verified session.", verifiedSession, is("verifiedSession1"));
+  }
+
+  @Test
+  void shouldGetEmptyVerifiedSession() {
+    Optional<String> verifiedSession = delegate.getVerifiedSession(UUID.randomUUID());
+    assertThat("Unexpected verified session.", verifiedSession, is(Optional.empty()));
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayServiceTest.java
@@ -45,6 +45,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties;
 import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties.IssuingProperties;
+import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties.VerificationProperties;
 import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDto;
 import uk.nhs.hee.tis.trainee.credentials.dto.PlacementCredentialDto;
 import uk.nhs.hee.tis.trainee.credentials.dto.ProgrammeMembershipCredentialDto;
@@ -72,8 +73,9 @@ class GatewayServiceTest {
 
     IssuingProperties issuingProperties = new IssuingProperties(PAR_ENDPOINT, AUTHORIZE_ENDPOINT,
         "", null, REDIRECT_URI);
+    VerificationProperties verificationProperties = new VerificationProperties("");
     GatewayProperties gatewayProperties = new GatewayProperties(CLIENT_ID, CLIENT_SECRET,
-        issuingProperties);
+        issuingProperties, verificationProperties);
 
     service = new GatewayService(restTemplate, jwtService, gatewayProperties);
   }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationServiceTest.java
@@ -1,0 +1,181 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties.VerificationProperties;
+import uk.nhs.hee.tis.trainee.credentials.dto.IdentityDataDto;
+
+class VerificationServiceTest {
+
+  private static final String AUTHORIZE_ENDPOINT = "https://credential.gateway/authorize/endpoint";
+
+  private VerificationService service;
+  private CachingDelegate cachingDelegate;
+
+  @BeforeEach
+  void setUp() {
+    cachingDelegate = spy(CachingDelegate.class);
+    VerificationProperties properties = new VerificationProperties(AUTHORIZE_ENDPOINT);
+    service = new VerificationService(cachingDelegate, properties);
+  }
+
+  @Test
+  void shouldCacheIdentityDataWhenStartingVerification() {
+    IdentityDataDto dto = new IdentityDataDto("Anthony", "Gilliam", LocalDate.now());
+
+    URI uri = service.startIdentityVerification(dto, null);
+
+    ArgumentCaptor<UUID> uuidCaptor = ArgumentCaptor.forClass(UUID.class);
+    verify(cachingDelegate).cacheIdentityData(uuidCaptor.capture(), eq(dto));
+
+    String uuid = uuidCaptor.getValue().toString();
+    Map<String, String> queryParams = splitQueryParams(uri);
+    assertThat("Unexpected cache key.", uuid, is(queryParams.get("nonce")));
+  }
+
+  @Test
+  void shouldCacheClientStateWhenStartingVerification() {
+    URI uri = service.startIdentityVerification(null, "some-client-state");
+
+    ArgumentCaptor<UUID> uuidCaptor = ArgumentCaptor.forClass(UUID.class);
+    verify(cachingDelegate).cacheClientState(uuidCaptor.capture(), eq("some-client-state"));
+
+    String uuid = uuidCaptor.getValue().toString();
+    Map<String, String> queryParams = splitQueryParams(uri);
+    assertThat("Unexpected cache key.", uuid, is(queryParams.get("state")));
+  }
+
+  @Test
+  void shouldCacheCodeVerifierWhenStartingVerification() {
+    URI uri = service.startIdentityVerification(null, null);
+
+    ArgumentCaptor<UUID> uuidCaptor = ArgumentCaptor.forClass(UUID.class);
+    verify(cachingDelegate).cacheCodeVerifier(uuidCaptor.capture(), any());
+
+    String uuid = uuidCaptor.getValue().toString();
+    Map<String, String> queryParams = splitQueryParams(uri);
+    assertThat("Unexpected cache key.", uuid, is(queryParams.get("state")));
+  }
+
+  @Test
+  void shouldUserAuthorizeEndpointWhenStartingVerification() {
+    URI uri = service.startIdentityVerification(null, null);
+
+    URI relativeUri = uri.relativize(URI.create(AUTHORIZE_ENDPOINT));
+    assertThat("Unexpected relative URI.", relativeUri, is(URI.create("")));
+  }
+
+  @Test
+  void shouldIncludeNonceWhenStartingVerification() {
+    URI uri = service.startIdentityVerification(null, null);
+
+    Map<String, String> queryParams = splitQueryParams(uri);
+    String nonce = queryParams.get("nonce");
+    assertDoesNotThrow(() -> UUID.fromString(nonce));
+  }
+
+  @Test
+  void shouldIncludeStateWhenStartingVerification() {
+    URI uri = service.startIdentityVerification(null, null);
+
+    Map<String, String> queryParams = splitQueryParams(uri);
+    String state = queryParams.get("state");
+    assertDoesNotThrow(() -> UUID.fromString(state));
+  }
+
+  @Test
+  void shouldIncludeCodeChallengeMethodWhenStartingVerification() {
+    URI uri = service.startIdentityVerification(null, null);
+
+    Map<String, String> queryParams = splitQueryParams(uri);
+    String codeChallengeMethod = queryParams.get("code_challenge_method");
+    assertThat("Unexpected query parameter value.", codeChallengeMethod, is("S256"));
+  }
+
+  @Test
+  void shouldIncludeCodeChallengeWhenStartingVerification() {
+    URI uri = service.startIdentityVerification(null, null);
+
+    Map<String, String> queryParams = splitQueryParams(uri);
+    String codeChallenge = queryParams.get("code_challenge");
+    assertThat("Unexpected query parameter value.", codeChallenge, notNullValue());
+  }
+
+  @Test
+  void shouldIncludeScopeWhenStartingVerification() {
+    URI uri = service.startIdentityVerification(null, null);
+
+    Map<String, String> queryParams = splitQueryParams(uri);
+    String scope = queryParams.get("scope");
+    assertThat("Unexpected query parameter value.", scope, is("openid+Identity"));
+  }
+
+  @Test
+  void shouldUsePkceChallengeWhenStartingVerification() {
+    URI uri = service.startIdentityVerification(null, null);
+
+    ArgumentCaptor<String> codeVerifierCaptor = ArgumentCaptor.forClass(String.class);
+    verify(cachingDelegate).cacheCodeVerifier(any(), codeVerifierCaptor.capture());
+
+    Map<String, String> queryParams = splitQueryParams(uri);
+    String codeChallengeParam = queryParams.get("code_challenge");
+
+    String coreVerifier = codeVerifierCaptor.getValue();
+    byte[] codeChallengeBytes = DigestUtils.sha256(coreVerifier);
+    String codeChallenge = Base64.getUrlEncoder().withoutPadding()
+        .encodeToString(codeChallengeBytes);
+    assertThat("Unexpected query parameter value.", codeChallengeParam, is(codeChallenge));
+  }
+
+  /**
+   * Split the query params of a URI in to a Map.
+   *
+   * @param uri The URI to split the query params from.
+   * @return A map of parameter names to value.
+   */
+  private Map<String, String> splitQueryParams(URI uri) {
+    return Arrays.stream(
+            uri.getQuery().split("&"))
+        .map(param -> param.split("="))
+        .collect(Collectors.toMap(keyValue -> keyValue[0], keyValue -> keyValue[1]));
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationServiceTest.java
@@ -97,7 +97,7 @@ class VerificationServiceTest {
   }
 
   @Test
-  void shouldUserAuthorizeEndpointWhenStartingVerification() {
+  void shouldUseAuthorizeEndpointWhenStartingVerification() {
     URI uri = service.startIdentityVerification(null, null);
 
     URI relativeUri = uri.relativize(URI.create(AUTHORIZE_ENDPOINT));
@@ -159,8 +159,8 @@ class VerificationServiceTest {
     Map<String, String> queryParams = splitQueryParams(uri);
     String codeChallengeParam = queryParams.get("code_challenge");
 
-    String coreVerifier = codeVerifierCaptor.getValue();
-    byte[] codeChallengeBytes = DigestUtils.sha256(coreVerifier);
+    String codeVerifier = codeVerifierCaptor.getValue();
+    byte[] codeChallengeBytes = DigestUtils.sha256(codeVerifier);
     String codeChallenge = Base64.getUrlEncoder().withoutPadding()
         .encodeToString(codeChallengeBytes);
     assertThat("Unexpected query parameter value.", codeChallengeParam, is(codeChallenge));

--- a/src/test/resources/application-redis.yml
+++ b/src/test/resources/application-redis.yml
@@ -1,0 +1,7 @@
+spring:
+  data:
+    redis:
+      host: ${embedded.redis.host}
+      port: ${embedded.redis.port}
+      user: ${embedded.redis.user}
+      password: ${embedded.redis.password}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,3 +1,8 @@
 application:
+  cache:
+    key-prefix: CredentialsTest
+    time-to-live:
+      verification-request: 60
+      verified-session: 60
   signature:
     secret-key: test-secret-key


### PR DESCRIPTION
Create an API endpoint to start the identity verification journey, the endpoint will accept and cache user identity data and then create a request URI the user can follow to provide an identity credential to the gateway.

Create a Redis caching layer, this will be used to cache data that must be available across requests. Such as identity data, client state and PKCE code verifiers. Internally generated states and nonces should be used as cache keys as appropriate.

Create a verification service which will manage the caching of required data and the generation of the URI to direct users to for verification.

Create an endpoint at `/api/verify/identity` which calls the service to start the verification flow.

TIS21-4181
TIS21-4182