### PR TITLE
feat: handle identity verification callback

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ dependencies {
   ext.jjwtVersion = "0.11.5"
   implementation "io.jsonwebtoken:jjwt-api:$jjwtVersion"
   runtimeOnly "io.jsonwebtoken:jjwt-impl:$jjwtVersion"
+  testImplementation "io.jsonwebtoken:jjwt-impl:$jjwtVersion"
   runtimeOnly "io.jsonwebtoken:jjwt-jackson:$jjwtVersion"
 
   testImplementation "org.springframework.cloud:spring-cloud-starter-bootstrap"

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.6.0"
+version = "0.7.0"
 
 configurations {
   compileOnly {
@@ -49,8 +49,7 @@ dependencies {
 
   ext.jjwtVersion = "0.11.5"
   implementation "io.jsonwebtoken:jjwt-api:$jjwtVersion"
-  runtimeOnly "io.jsonwebtoken:jjwt-impl:$jjwtVersion"
-  testImplementation "io.jsonwebtoken:jjwt-impl:$jjwtVersion"
+  implementation "io.jsonwebtoken:jjwt-impl:$jjwtVersion"
   runtimeOnly "io.jsonwebtoken:jjwt-jackson:$jjwtVersion"
 
   testImplementation "org.springframework.cloud:spring-cloud-starter-bootstrap"

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/VerifyResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/VerifyResource.java
@@ -25,12 +25,14 @@ import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.validator.constraints.UUID;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -54,11 +56,11 @@ public class VerifyResource {
   }
 
   @PostMapping("/identity")
-  ResponseEntity<String> verifyIdentity(
+  ResponseEntity<String> verifyIdentity(@RequestHeader(HttpHeaders.AUTHORIZATION) String authToken,
       @RequestParam(required = false) String state,
       @Valid @RequestBody IdentityDataDto dto) {
     log.info("Received request to start identity verification.");
-    URI uri = service.startIdentityVerification(dto, state);
+    URI uri = service.startIdentityVerification(authToken, dto, state);
 
     log.info("Identity verification successfully started.");
     return ResponseEntity.created(uri).body(uri.toString());

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/VerifyResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/VerifyResource.java
@@ -71,7 +71,7 @@ public class VerifyResource {
       @ValidScope @RequestParam String scope,
       @UUID @RequestParam String state) {
     log.info("Received callback for credential verification.");
-    URI uri = service.completeVerification(code, scope, state);
+    URI uri = service.completeCredentialVerification(code, scope, state);
 
     log.info("Credential verification completed.");
     return ResponseEntity.status(HttpStatus.FOUND).location(uri).build();

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayService.java
@@ -177,8 +177,15 @@ public class GatewayService {
     }
     log.info("Received token response.");
 
+    TokenResponse body = tokenResponse.getBody();
+
+    if (body == null) {
+      log.error("Token response was empty.");
+      return new DefaultClaims();
+    }
+
     // TODO: verify token against public key
-    String signedToken = tokenResponse.getBody().idToken();
+    String signedToken = body.idToken();
     return jwtService.getClaims(signedToken);
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayService.java
@@ -22,6 +22,8 @@
 package uk.nhs.hee.tis.trainee.credentials.service;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.impl.DefaultClaims;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
@@ -147,6 +149,71 @@ public class GatewayService {
    * @param requestUri The returned request_uri value.
    */
   record ParResponse(@JsonProperty("request_uri") String requestUri) {
+
+  }
+
+  /**
+   * Call a token code endpoint and extract the claims from the resulting token.
+   *
+   * @param endpoint     The token endpoint.
+   * @param redirectUri  The redirect endpoint sent with the initial request.
+   * @param code         The code resulting from the initial request.
+   * @param codeVerifier The code PKCE code verifier matching the challenge sent with the initial
+   *                     request.
+   * @return The extracted claims.
+   */
+  public Claims getTokenClaims(URI endpoint, URI redirectUri, String code, String codeVerifier) {
+    String state = UUID.randomUUID().toString();
+    HttpEntity<MultiValueMap<String, String>> request = buildTokenRequest(redirectUri, code,
+        codeVerifier, state);
+
+    log.info("Sending token request.");
+    ResponseEntity<TokenResponse> tokenResponse = restTemplate.postForEntity(endpoint, request,
+        TokenResponse.class);
+
+    if (tokenResponse.getStatusCode().isError()) {
+      log.error("Token request failed with code {}.", tokenResponse.getStatusCode());
+      return new DefaultClaims();
+    }
+    log.info("Received token response.");
+
+    // TODO: verify token against public key
+    String signedToken = tokenResponse.getBody().idToken();
+    return jwtService.getClaims(signedToken);
+  }
+
+  /**
+   * Build a request to get a token for the given code.
+   *
+   * @param redirectUri  The redirect endpoint sent with the initial request.
+   * @param code         The code resulting from the initial request.
+   * @param codeVerifier The code PKCE code verifier matching the challenge sent with the initial
+   *                     request.
+   * @param state        The state to include in the request.
+   * @return The built token request.
+   */
+  private HttpEntity<MultiValueMap<String, String>> buildTokenRequest(URI redirectUri, String code,
+      String codeVerifier, String state) {
+    log.info("Building Token request.");
+
+    MultiValueMap<String, String> bodyPair = new LinkedMultiValueMap<>();
+    bodyPair.add("client_id", properties.clientId());
+    bodyPair.add("client_secret", properties.clientSecret());
+    bodyPair.add("redirect_uri", redirectUri.toString());
+    bodyPair.add("grant_type", "authorization_code");
+    bodyPair.add("code", code);
+    bodyPair.add("code_verifier", codeVerifier);
+    bodyPair.add("state", state);
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+    log.info("Built Token request.");
+    return new HttpEntity<>(bodyPair, headers);
+  }
+
+  record TokenResponse(@JsonProperty("id_token") String idToken) {
 
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationService.java
@@ -104,7 +104,7 @@ public class VerificationService {
 
     // Build and return the URI at which the user can provide an identity credential.
     return UriComponentsBuilder.fromUriString(properties.authorizeEndpoint())
-        .queryParam("nonce", nonce)
+        .queryParam(CLAIM_NONCE, nonce)
         .queryParam("state", internalState)
         .queryParam("code_challenge_method", "S256")
         .queryParam("code_challenge", codeChallenge)

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/api/VerifyResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/api/VerifyResourceTest.java
@@ -310,7 +310,7 @@ class VerifyResourceTest {
 
   @Test
   void shouldRedirectWhenVerificationCompleted() throws Exception {
-    when(service.completeVerification(CODE_VALUE, SCOPE_VALUE, STATE_VALUE)).thenReturn(
+    when(service.completeCredentialVerification(CODE_VALUE, SCOPE_VALUE, STATE_VALUE)).thenReturn(
         URI.create("test-redirect"));
 
     mockMvc.perform(

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayServiceTest.java
@@ -305,6 +305,18 @@ class GatewayServiceTest {
   }
 
   @Test
+  void shouldReturnEmptyClaimsWhenTokenResponseEmpty() {
+    URI tokenEndpoint = URI.create(TOKEN_ENDPOINT);
+
+    when(restTemplate.postForEntity(eq(tokenEndpoint), any(), eq(TokenResponse.class))).thenReturn(
+        ResponseEntity.ok().build());
+
+    Claims claims = service.getTokenClaims(tokenEndpoint, URI.create(REDIRECT_URI), "", "");
+
+    assertThat("Unexpected claim count.", claims.size(), is(0));
+  }
+
+  @Test
   void shouldReturnTokenClaimsWhenTokenResponseOk() {
     URI tokenEndpoint = URI.create(TOKEN_ENDPOINT);
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationServiceTest.java
@@ -21,7 +21,9 @@
 
 package uk.nhs.hee.tis.trainee.credentials.service;
 
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -38,6 +40,7 @@ import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -49,11 +52,26 @@ import uk.nhs.hee.tis.trainee.credentials.dto.IdentityDataDto;
 
 class VerificationServiceTest {
 
-  private static final String AUTHORIZE_ENDPOINT = "https://credential.gateway/authorize/endpoint";
-  private static final String TOKEN_ENDPOINT = "https://credential.gateway/token/endpoint";
-  private static final String REDIRECT_URI = "https://credential.service/redirect-uri";
+  private static final URI AUTHORIZE_ENDPOINT = URI.create(
+      "https://credential.gateway/authorize/endpoint");
+  private static final URI TOKEN_ENDPOINT = URI.create("https://credential.gateway/token/endpoint");
+  private static final URI REDIRECT_URI = URI.create("https://credential.service/redirect-uri");
 
   private static final String AUTH_TOKEN = "dummy-auth-token";
+  private static final String CODE = "code";
+  private static final String IDENTITY_SCOPE = "openid Identity";
+
+  private static final String QUERY_PARAM_REASON = "reason";
+  private static final String QUERY_PARAM_SCOPE = "scope";
+  private static final String QUERY_PARAM_STATE = "state";
+  private static final String CLAIM_NONCE = "nonce";
+  private static final String CLAIM_FIRST_NAME = "Identity.ID-LegalFirstName";
+  private static final String CLAIM_FAMILY_NAME = "Identity.ID-LegalSurname";
+  private static final String CLAIM_BIRTH_DATE = "Identity.ID-BirthDate";
+
+  private static final String IDENTITY_FORENAMES = "Anthony";
+  private static final String IDENTITY_SURNAME = "Gilliam";
+  private static final LocalDate IDENTITY_DOB = LocalDate.parse("1991-11-11");
 
   private VerificationService verificationService;
   private GatewayService gatewayService;
@@ -65,8 +83,10 @@ class VerificationServiceTest {
     gatewayService = mock(GatewayService.class);
     jwtService = mock(JwtService.class);
     cachingDelegate = spy(CachingDelegate.class);
-    var properties = new VerificationProperties(AUTHORIZE_ENDPOINT, TOKEN_ENDPOINT, REDIRECT_URI);
-    verificationService = new VerificationService(jwtService, cachingDelegate, properties);
+    var properties = new VerificationProperties(AUTHORIZE_ENDPOINT.toString(),
+        TOKEN_ENDPOINT.toString(), REDIRECT_URI.toString());
+    verificationService = new VerificationService(gatewayService, jwtService, cachingDelegate,
+        properties);
   }
 
   @Test
@@ -82,7 +102,7 @@ class VerificationServiceTest {
 
     String uuid = uuidCaptor.getValue().toString();
     Map<String, String> queryParams = splitQueryParams(uri);
-    assertThat("Unexpected cache key.", uuid, is(queryParams.get("nonce")));
+    assertThat("Unexpected cache key.", uuid, is(queryParams.get(CLAIM_NONCE)));
   }
 
   @Test
@@ -96,7 +116,7 @@ class VerificationServiceTest {
 
     String uuid = uuidCaptor.getValue().toString();
     Map<String, String> queryParams = splitQueryParams(uri);
-    assertThat("Unexpected cache key.", uuid, is(queryParams.get("state")));
+    assertThat("Unexpected cache key.", uuid, is(queryParams.get(QUERY_PARAM_STATE)));
   }
 
   @Test
@@ -110,7 +130,7 @@ class VerificationServiceTest {
 
     String uuid = uuidCaptor.getValue().toString();
     Map<String, String> queryParams = splitQueryParams(uri);
-    assertThat("Unexpected cache key.", uuid, is(queryParams.get("state")));
+    assertThat("Unexpected cache key.", uuid, is(queryParams.get(QUERY_PARAM_STATE)));
   }
 
   @Test
@@ -128,7 +148,7 @@ class VerificationServiceTest {
 
     String uuid = uuidCaptor.getValue().toString();
     Map<String, String> queryParams = splitQueryParams(uri);
-    assertThat("Unexpected cache key.", uuid, is(queryParams.get("nonce")));
+    assertThat("Unexpected cache key.", uuid, is(queryParams.get(CLAIM_NONCE)));
   }
 
   @Test
@@ -137,7 +157,7 @@ class VerificationServiceTest {
 
     URI uri = verificationService.startIdentityVerification(AUTH_TOKEN, null, null);
 
-    URI relativeUri = uri.relativize(URI.create(AUTHORIZE_ENDPOINT));
+    URI relativeUri = uri.relativize(AUTHORIZE_ENDPOINT);
     assertThat("Unexpected relative URI.", relativeUri, is(URI.create("")));
   }
 
@@ -147,7 +167,7 @@ class VerificationServiceTest {
     URI uri = verificationService.startIdentityVerification(AUTH_TOKEN, null, null);
 
     Map<String, String> queryParams = splitQueryParams(uri);
-    String nonce = queryParams.get("nonce");
+    String nonce = queryParams.get(CLAIM_NONCE);
     assertDoesNotThrow(() -> UUID.fromString(nonce));
   }
 
@@ -158,7 +178,7 @@ class VerificationServiceTest {
     URI uri = verificationService.startIdentityVerification(AUTH_TOKEN, null, null);
 
     Map<String, String> queryParams = splitQueryParams(uri);
-    String state = queryParams.get("state");
+    String state = queryParams.get(QUERY_PARAM_STATE);
     assertDoesNotThrow(() -> UUID.fromString(state));
   }
 
@@ -191,7 +211,7 @@ class VerificationServiceTest {
     URI uri = verificationService.startIdentityVerification(AUTH_TOKEN, null, null);
 
     Map<String, String> queryParams = splitQueryParams(uri);
-    String scope = queryParams.get("scope");
+    String scope = queryParams.get(QUERY_PARAM_SCOPE);
     assertThat("Unexpected query parameter value.", scope, is("openid+Identity"));
   }
 
@@ -212,6 +232,266 @@ class VerificationServiceTest {
     String codeChallenge = Base64.getUrlEncoder().withoutPadding()
         .encodeToString(codeChallengeBytes);
     assertThat("Unexpected query parameter value.", codeChallengeParam, is(codeChallenge));
+  }
+
+  @Test
+  void shouldReturnInvalidCredentialWhenNoCachedCodeVerifier() {
+    UUID state = UUID.randomUUID();
+    when(cachingDelegate.getCodeVerifier(state)).thenReturn(Optional.empty());
+
+    URI uri = verificationService.completeCredentialVerification(CODE, IDENTITY_SCOPE,
+        state.toString());
+
+    assertThat("Unexpected URI path.", uri.getPath(), is("/invalid-credential"));
+
+    Map<String, String> queryParams = splitQueryParams(uri);
+    String reason = queryParams.get(QUERY_PARAM_REASON);
+    assertThat("Unexpected invalid reason.", reason, is("no_code_verifier"));
+  }
+
+  @Test
+  void shouldReturnInvalidCredentialWhenUnsupportedCredentialScope() {
+    UUID state = UUID.randomUUID();
+    String codeVerifier = "code-verifier";
+
+    when(cachingDelegate.getCodeVerifier(state)).thenReturn(Optional.of(codeVerifier));
+    when(gatewayService.getTokenClaims(TOKEN_ENDPOINT, REDIRECT_URI, CODE, codeVerifier))
+        .thenReturn(new DefaultClaims());
+
+    URI uri = verificationService.completeCredentialVerification(CODE, "invalid-scope",
+        state.toString());
+
+    assertThat("Unexpected URI path.", uri.getPath(), is("/invalid-credential"));
+
+    Map<String, String> queryParams = splitQueryParams(uri);
+    String reason = queryParams.get(QUERY_PARAM_REASON);
+    assertThat("Unexpected invalid reason.", reason, is("unsupported_scope"));
+  }
+
+  @Test
+  void shouldReturnInvalidCredentialWhenIdentityVerificationFailsOnMissingIdentity() {
+    UUID state = UUID.randomUUID();
+    String codeVerifier = "code-verifier";
+    when(cachingDelegate.getCodeVerifier(state)).thenReturn(Optional.of(codeVerifier));
+
+    UUID nonce = UUID.randomUUID();
+    DefaultClaims claims = new DefaultClaims(Map.of(CLAIM_NONCE, nonce.toString()));
+    when(gatewayService.getTokenClaims(TOKEN_ENDPOINT, REDIRECT_URI, CODE, codeVerifier))
+        .thenReturn(claims);
+    when(cachingDelegate.getIdentityData(nonce)).thenReturn(Optional.empty());
+
+    URI uri = verificationService.completeCredentialVerification(CODE, IDENTITY_SCOPE,
+        state.toString());
+
+    assertThat("Unexpected URI path.", uri.getPath(), is("/invalid-credential"));
+
+    Map<String, String> queryParams = splitQueryParams(uri);
+    String reason = queryParams.get(QUERY_PARAM_REASON);
+    assertThat("Unexpected invalid reason.", reason, is("identity_verification_failed"));
+  }
+
+  @Test
+  void shouldReturnInvalidCredentialWhenIdentityVerificationFailsOnForenames() {
+    UUID state = UUID.randomUUID();
+    String codeVerifier = "code-verifier";
+    when(cachingDelegate.getCodeVerifier(state)).thenReturn(Optional.of(codeVerifier));
+
+    UUID nonce = UUID.randomUUID();
+    DefaultClaims claims = new DefaultClaims(Map.of(
+        CLAIM_NONCE, nonce.toString(),
+        CLAIM_FIRST_NAME, "mismatch",
+        CLAIM_FAMILY_NAME, IDENTITY_SURNAME,
+        CLAIM_BIRTH_DATE, IDENTITY_DOB.toString()));
+    when(gatewayService.getTokenClaims(TOKEN_ENDPOINT, REDIRECT_URI, CODE, codeVerifier))
+        .thenReturn(claims);
+    when(cachingDelegate.getUnverifiedSessionIdentifier(nonce)).thenReturn(
+        Optional.of("session123"));
+
+    IdentityDataDto identityData = new IdentityDataDto(IDENTITY_FORENAMES, IDENTITY_SURNAME,
+        IDENTITY_DOB);
+    when(cachingDelegate.getIdentityData(nonce)).thenReturn(Optional.of(identityData));
+
+    URI uri = verificationService.completeCredentialVerification(CODE, IDENTITY_SCOPE,
+        state.toString());
+
+    assertThat("Unexpected URI path.", uri.getPath(), is("/invalid-credential"));
+
+    Map<String, String> queryParams = splitQueryParams(uri);
+    String reason = queryParams.get(QUERY_PARAM_REASON);
+    assertThat("Unexpected invalid reason.", reason, is("identity_verification_failed"));
+  }
+
+  @Test
+  void shouldReturnInvalidCredentialWhenIdentityVerificationFailsOnSurname() {
+    UUID state = UUID.randomUUID();
+    String codeVerifier = "code-verifier";
+    when(cachingDelegate.getCodeVerifier(state)).thenReturn(Optional.of(codeVerifier));
+
+    UUID nonce = UUID.randomUUID();
+    DefaultClaims claims = new DefaultClaims(Map.of(
+        CLAIM_NONCE, nonce.toString(),
+        CLAIM_FIRST_NAME, IDENTITY_FORENAMES,
+        CLAIM_FAMILY_NAME, "mismatch",
+        CLAIM_BIRTH_DATE, IDENTITY_DOB.toString()));
+    when(gatewayService.getTokenClaims(TOKEN_ENDPOINT, REDIRECT_URI, CODE, codeVerifier))
+        .thenReturn(claims);
+    when(cachingDelegate.getUnverifiedSessionIdentifier(nonce)).thenReturn(
+        Optional.of("session123"));
+
+    IdentityDataDto identityData = new IdentityDataDto(IDENTITY_FORENAMES, IDENTITY_SURNAME,
+        IDENTITY_DOB);
+    when(cachingDelegate.getIdentityData(nonce)).thenReturn(Optional.of(identityData));
+
+    URI uri = verificationService.completeCredentialVerification(CODE, IDENTITY_SCOPE,
+        state.toString());
+
+    assertThat("Unexpected URI path.", uri.getPath(), is("/invalid-credential"));
+
+    Map<String, String> queryParams = splitQueryParams(uri);
+    String reason = queryParams.get(QUERY_PARAM_REASON);
+    assertThat("Unexpected invalid reason.", reason, is("identity_verification_failed"));
+  }
+
+  @Test
+  void shouldReturnInvalidCredentialWhenIdentityVerificationFailsOnDob() {
+    UUID state = UUID.randomUUID();
+    String codeVerifier = "code-verifier";
+    when(cachingDelegate.getCodeVerifier(state)).thenReturn(Optional.of(codeVerifier));
+
+    UUID nonce = UUID.randomUUID();
+    DefaultClaims claims = new DefaultClaims(Map.of(
+        CLAIM_NONCE, nonce.toString(),
+        CLAIM_FIRST_NAME, IDENTITY_FORENAMES,
+        CLAIM_FAMILY_NAME, IDENTITY_SURNAME,
+        CLAIM_BIRTH_DATE, LocalDate.now().toString()));
+    when(gatewayService.getTokenClaims(TOKEN_ENDPOINT, REDIRECT_URI, CODE, codeVerifier))
+        .thenReturn(claims);
+    when(cachingDelegate.getUnverifiedSessionIdentifier(nonce)).thenReturn(
+        Optional.of("session123"));
+
+    IdentityDataDto identityData = new IdentityDataDto(IDENTITY_FORENAMES, IDENTITY_SURNAME,
+        IDENTITY_DOB);
+    when(cachingDelegate.getIdentityData(nonce)).thenReturn(Optional.of(identityData));
+
+    URI uri = verificationService.completeCredentialVerification(CODE, IDENTITY_SCOPE,
+        state.toString());
+
+    assertThat("Unexpected URI path.", uri.getPath(), is("/invalid-credential"));
+
+    Map<String, String> queryParams = splitQueryParams(uri);
+    String reason = queryParams.get(QUERY_PARAM_REASON);
+    assertThat("Unexpected invalid reason.", reason, is("identity_verification_failed"));
+  }
+
+  @Test
+  void shouldReturnInvalidCredentialWhenIdentityVerificationFailsOnMissingSession() {
+    UUID state = UUID.randomUUID();
+    String codeVerifier = "code-verifier";
+    when(cachingDelegate.getCodeVerifier(state)).thenReturn(Optional.of(codeVerifier));
+
+    UUID nonce = UUID.randomUUID();
+    DefaultClaims claims = new DefaultClaims(Map.of(
+        CLAIM_NONCE, nonce.toString(),
+        CLAIM_FIRST_NAME, IDENTITY_FORENAMES,
+        CLAIM_FAMILY_NAME, IDENTITY_SURNAME,
+        CLAIM_BIRTH_DATE, IDENTITY_DOB.toString()));
+    when(gatewayService.getTokenClaims(TOKEN_ENDPOINT, REDIRECT_URI, CODE, codeVerifier))
+        .thenReturn(claims);
+    when(cachingDelegate.getUnverifiedSessionIdentifier(nonce)).thenReturn(Optional.empty());
+
+    IdentityDataDto identityData = new IdentityDataDto(IDENTITY_FORENAMES, IDENTITY_SURNAME,
+        IDENTITY_DOB);
+    when(cachingDelegate.getIdentityData(nonce)).thenReturn(Optional.of(identityData));
+
+    URI uri = verificationService.completeCredentialVerification(CODE, IDENTITY_SCOPE,
+        state.toString());
+
+    assertThat("Unexpected URI path.", uri.getPath(), is("/invalid-credential"));
+
+    Map<String, String> queryParams = splitQueryParams(uri);
+    String reason = queryParams.get(QUERY_PARAM_REASON);
+    assertThat("Unexpected invalid reason.", reason, is("identity_verification_failed"));
+  }
+
+  @Test
+  void shouldReturnCredentialVerifiedWhenIdentityVerificationPasses() {
+    UUID state = UUID.randomUUID();
+    String codeVerifier = "code-verifier";
+    when(cachingDelegate.getCodeVerifier(state)).thenReturn(Optional.of(codeVerifier));
+
+    UUID nonce = UUID.randomUUID();
+    DefaultClaims claims = new DefaultClaims(Map.of(
+        CLAIM_NONCE, nonce.toString(),
+        CLAIM_FIRST_NAME, IDENTITY_FORENAMES,
+        CLAIM_FAMILY_NAME, IDENTITY_SURNAME,
+        CLAIM_BIRTH_DATE, IDENTITY_DOB.toString()));
+    when(gatewayService.getTokenClaims(TOKEN_ENDPOINT, REDIRECT_URI, CODE, codeVerifier))
+        .thenReturn(claims);
+    when(cachingDelegate.getUnverifiedSessionIdentifier(nonce)).thenReturn(
+        Optional.of("session123"));
+
+    IdentityDataDto identityData = new IdentityDataDto(IDENTITY_FORENAMES, IDENTITY_SURNAME,
+        IDENTITY_DOB);
+    when(cachingDelegate.getIdentityData(nonce)).thenReturn(Optional.of(identityData));
+
+    URI uri = verificationService.completeCredentialVerification(CODE, IDENTITY_SCOPE,
+        state.toString());
+
+    assertThat("Unexpected URI path.", uri.getPath(), is("/credential-verified"));
+  }
+
+  @Test
+  void shouldCacheVerifiedSessionWhenIdentityVerificationPasses() {
+    UUID state = UUID.randomUUID();
+    String codeVerifier = "code-verifier";
+    when(cachingDelegate.getCodeVerifier(state)).thenReturn(Optional.of(codeVerifier));
+
+    UUID nonce = UUID.randomUUID();
+    DefaultClaims claims = new DefaultClaims(Map.of(
+        CLAIM_NONCE, nonce.toString(),
+        CLAIM_FIRST_NAME, IDENTITY_FORENAMES,
+        CLAIM_FAMILY_NAME, IDENTITY_SURNAME,
+        CLAIM_BIRTH_DATE, IDENTITY_DOB.toString()));
+    when(gatewayService.getTokenClaims(TOKEN_ENDPOINT, REDIRECT_URI, CODE, codeVerifier))
+        .thenReturn(claims);
+    when(cachingDelegate.getUnverifiedSessionIdentifier(nonce)).thenReturn(
+        Optional.of("session123"));
+
+    IdentityDataDto identityData = new IdentityDataDto(IDENTITY_FORENAMES, IDENTITY_SURNAME,
+        IDENTITY_DOB);
+    when(cachingDelegate.getIdentityData(nonce)).thenReturn(Optional.of(identityData));
+
+    verificationService.completeCredentialVerification(CODE, IDENTITY_SCOPE, state.toString());
+
+    verify(cachingDelegate).cacheVerifiedSessionIdentifier("session123");
+  }
+
+  @Test
+  void shouldReturnStateWhenClientStateCached() {
+    UUID state = UUID.randomUUID();
+    when(cachingDelegate.getCodeVerifier(state)).thenReturn(Optional.empty());
+    when(cachingDelegate.getClientState(state)).thenReturn(Optional.of("client-state"));
+
+    URI uri = verificationService.completeCredentialVerification(CODE, IDENTITY_SCOPE,
+        state.toString());
+
+    Map<String, String> queryParams = splitQueryParams(uri);
+    String clientState = queryParams.get(QUERY_PARAM_STATE);
+    assertThat("Unexpected client state.", clientState, is("client-state"));
+  }
+
+  @Test
+  void shouldNotReturnStateWhenClientStateNotCached() {
+    UUID state = UUID.randomUUID();
+    when(cachingDelegate.getCodeVerifier(state)).thenReturn(Optional.empty());
+    when(cachingDelegate.getClientState(state)).thenReturn(Optional.empty());
+
+    URI uri = verificationService.completeCredentialVerification(CODE, IDENTITY_SCOPE,
+        state.toString());
+
+    Map<String, String> queryParams = splitQueryParams(uri);
+    assertThat("Unexpected client state presence.", queryParams.keySet(),
+        not(hasItem(QUERY_PARAM_STATE)));
   }
 
   /**


### PR DESCRIPTION
When the callback is hit the provided code will be exchanged for a token, which is then compared against the previously cached identity data.

If the identity is confirmed, then a verified session identifier is cached for allowing issuing credentials later.

TIS21-4177