### PR TITLE
Feat/handle identity verification

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.7.0"
+version = "0.8.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/GatewayProperties.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/GatewayProperties.java
@@ -26,14 +26,19 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * A representation of the credential gateway properties.
  *
+ * @param host         The gateway host.
  * @param clientId     The gateway client ID.
  * @param clientSecret The gateway client secret.
+ * @param jwksEndpoint The endpoint for JWKS document.
  * @param issuing      The issuing child properties.
+ * @param verification The verification child properties.
  */
 @ConfigurationProperties(prefix = "application.gateway")
 public record GatewayProperties(
+    String host,
     String clientId,
     String clientSecret,
+    String jwksEndpoint,
     IssuingProperties issuing,
     VerificationProperties verification) {
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegate.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegate.java
@@ -24,6 +24,7 @@ package uk.nhs.hee.tis.trainee.credentials.service;
 import static uk.nhs.hee.tis.trainee.credentials.config.CacheConfiguration.VERIFICATION_REQUEST_DATA;
 import static uk.nhs.hee.tis.trainee.credentials.config.CacheConfiguration.VERIFIED_SESSION_DATA;
 
+import java.security.PublicKey;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.cache.annotation.CacheEvict;
@@ -41,9 +42,10 @@ class CachingDelegate {
 
   private static final String CLIENT_STATE = "ClientState";
   private static final String CODE_VERIFIER = "CodeVerifier";
-  public static final String IDENTITY_DATA = "IdentityData";
-  public static final String UNVERIFIED_SESSION_IDENTIFIER = "SessionIdentifier::Unverified";
-  public static final String VERIFIED_SESSION_IDENTIFIER = "SessionIdentifier::Verified";
+  private static final String IDENTITY_DATA = "IdentityData";
+  private static final String PUBLIC_KEY = "PublicKey";
+  private static final String UNVERIFIED_SESSION_IDENTIFIER = "SessionIdentifier::Unverified";
+  private static final String VERIFIED_SESSION_IDENTIFIER = "SessionIdentifier::Verified";
 
   /**
    * Cache a PKCE code verifier for later retrieval.
@@ -114,6 +116,29 @@ class CachingDelegate {
   @Cacheable(cacheNames = CLIENT_STATE, cacheManager = VERIFICATION_REQUEST_DATA)
   @CacheEvict(CLIENT_STATE)
   public Optional<String> getClientState(UUID key) {
+    return Optional.empty();
+  }
+
+  /**
+   * Cache a public key for later retrieval.
+   *
+   * @param certificateThumbprint The certificate thumbprint.
+   * @param publicKey             The public key to cache.
+   * @return The cached public key.
+   */
+  @CachePut(cacheNames = PUBLIC_KEY, key = "#certificateThumbprint")
+  public PublicKey cachePublicKey(String certificateThumbprint, PublicKey publicKey) {
+    return publicKey;
+  }
+
+  /**
+   * Get the public key associated with the give certificate thumbprint.
+   *
+   * @param certificateThumbprint The certificate thumbprint.
+   * @return The cached public key, or an empty optional if not found.
+   */
+  @Cacheable(cacheNames = PUBLIC_KEY)
+  public Optional<PublicKey> getPublicKey(String certificateThumbprint) {
     return Optional.empty();
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayService.java
@@ -184,9 +184,8 @@ public class GatewayService {
       return new DefaultClaims();
     }
 
-    // TODO: verify token against public key
     String signedToken = body.idToken();
-    return jwtService.getClaims(signedToken);
+    return jwtService.getClaims(signedToken, true);
   }
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/PublicKeyResolver.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/PublicKeyResolver.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Objects;
 import java.util.Optional;
+import lombok.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties;
@@ -74,8 +75,8 @@ public class PublicKeyResolver extends SigningKeyResolverAdapter {
 
     Jwks jwks = getJwks(claims);
 
-    PublicKey publicKey = Arrays.stream(jwks.keys())
-        .filter(key -> key.x5t().equals(tokenThumbprint))
+    PublicKey publicKey = Arrays.stream(jwks.getKeys())
+        .filter(key -> key.getX5t().equals(tokenThumbprint))
         .map(this::getPublicKey)
         .findFirst()
         .orElseThrow(
@@ -112,7 +113,7 @@ public class PublicKeyResolver extends SigningKeyResolverAdapter {
    * @return The public key.
    */
   private PublicKey getPublicKey(Jwk key) {
-    byte[] keyBytes = Base64.getDecoder().decode(key.x5c[0]);
+    byte[] keyBytes = Base64.getDecoder().decode(key.getX5c()[0]);
 
     try {
       CertificateFactory certificateFactory = CertificateFactory.getInstance(CERTIFICATE_TYPE);
@@ -126,26 +127,20 @@ public class PublicKeyResolver extends SigningKeyResolverAdapter {
 
   /**
    * A JWKs document, with an array of JWK keys.
-   *
-   * @param keys The JWKs
    */
-  record Jwks(Jwk[] keys) {
+  @Value
+  static class Jwks {
+
+    Jwk[] keys;
 
     /**
-     * A representation of a JWK.
-     *
-     * @param kty The key type, identifies the cryptographic algorithm family used with the key.
-     * @param use Public key use, identifies the intended use of the public key.
-     * @param alg The algorithm, identifies the algorithm intended for use with the key.
-     * @param kid The key identifier, used to match a specific key.
-     * @param x5c X.509 certificate chain.
-     * @param x5t X.509 certificate SHA-1 thumbprint.
-     * @param e   The "e" (exponent) parameter, contains the exponent value for the RSA public key.
-     * @param n   The "n" (modulus) parameter, contains the modulus value for the RSA public key.
+     * A representation of a JWK, unused fields have been excluded for simplicity.
      */
-    record Jwk(String kty, String use, String alg, String kid, String[] x5c, String x5t, String e,
-               String n) {
+    @Value
+    static class Jwk {
 
+      String[] x5c; // X.509 certificate chain.
+      String x5t; // X.509 certificate SHA-1 thumbprint.
     }
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/PublicKeyResolver.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/PublicKeyResolver.java
@@ -1,0 +1,151 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.SigningKeyResolverAdapter;
+import java.io.ByteArrayInputStream;
+import java.security.Key;
+import java.security.PublicKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties;
+import uk.nhs.hee.tis.trainee.credentials.service.PublicKeyResolver.Jwks.Jwk;
+
+/**
+ * A signing key resolver which uses cached public keys before requesting via a JWKs endpoints.
+ */
+@Component
+public class PublicKeyResolver extends SigningKeyResolverAdapter {
+
+  private static final String CERTIFICATE_TYPE = "X.509";
+
+  private final CachingDelegate cachingDelegate;
+  private final RestTemplate restTemplate;
+  private final GatewayProperties properties;
+
+  PublicKeyResolver(CachingDelegate cachingDelegate, RestTemplate restTemplate,
+      GatewayProperties properties) {
+    this.cachingDelegate = cachingDelegate;
+    this.restTemplate = restTemplate;
+    this.properties = properties;
+  }
+
+  @Override
+  public Key resolveSigningKey(JwsHeader header, Claims claims) {
+    String tokenThumbprint = (String) header.get(JwsHeader.X509_CERT_SHA1_THUMBPRINT);
+
+    if (tokenThumbprint == null) {
+      throw new IllegalArgumentException("Not certificate thumbprint in headers.");
+    }
+
+    Optional<PublicKey> cachedPublicKey = cachingDelegate.getPublicKey(tokenThumbprint);
+
+    if (cachedPublicKey.isPresent()) {
+      return cachedPublicKey.get();
+    }
+
+    Jwks jwks = getJwks(claims);
+
+    PublicKey publicKey = Arrays.stream(jwks.keys())
+        .filter(key -> key.x5t().equals(tokenThumbprint))
+        .map(this::getPublicKey)
+        .findFirst()
+        .orElseThrow(
+            () -> new IllegalArgumentException("Can not resolve public key for given token."));
+
+    return cachingDelegate.cachePublicKey(tokenThumbprint, publicKey);
+  }
+
+  /**
+   * Get the JWKs document associated with the claims.
+   *
+   * @param claims The token claims, issuer must be populated.
+   * @return The Jwks document.
+   */
+  private Jwks getJwks(Claims claims) {
+    String issuer = claims.getIssuer();
+
+    if (Objects.equals(issuer, properties.host())) {
+      Jwks jwks = restTemplate.getForObject(properties.jwksEndpoint(), Jwks.class);
+
+      if (jwks != null) {
+        return jwks;
+      }
+    }
+
+    String message = String.format("Invalid token issuer '%s'.", issuer);
+    throw new IllegalArgumentException(message);
+  }
+
+  /**
+   * Get the {@link PublicKey} from the given {@link Jwk}s certificate.
+   *
+   * @param key The JWK to get the public key from.
+   * @return The public key.
+   */
+  private PublicKey getPublicKey(Jwk key) {
+    byte[] keyBytes = Base64.getDecoder().decode(key.x5c[0]);
+
+    try {
+      CertificateFactory certificateFactory = CertificateFactory.getInstance(CERTIFICATE_TYPE);
+      Certificate certificate = certificateFactory.generateCertificate(
+          new ByteArrayInputStream(keyBytes));
+      return certificate.getPublicKey();
+    } catch (CertificateException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  /**
+   * A JWKs document, with an array of JWK keys.
+   *
+   * @param keys The JWKs
+   */
+  record Jwks(Jwk[] keys) {
+
+    /**
+     * A representation of a JWK.
+     *
+     * @param kty The key type, identifies the cryptographic algorithm family used with the key.
+     * @param use Public key use, identifies the intended use of the public key.
+     * @param alg The algorithm, identifies the algorithm intended for use with the key.
+     * @param kid The key identifier, used to match a specific key.
+     * @param x5c X.509 certificate chain.
+     * @param x5t X.509 certificate SHA-1 thumbprint.
+     * @param e   The "e" (exponent) parameter, contains the exponent value for the RSA public key.
+     * @param n   The "n" (modulus) parameter, contains the modulus value for the RSA public key.
+     */
+    record Jwk(String kty, String use, String alg, String kid, String[] x5c, String x5t, String e,
+               String n) {
+
+    }
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,21 +10,22 @@ application:
       verification-request: ${REDIS_TTL_VERIFICATION_REQUEST:300}
       verified-session: ${REDIS_TTL_VERIFIED_SESSION:600}
   gateway:
-    host: ${GATEWAY_HOST}
+    host: https://${GATEWAY_HOST}
     client-id: ${GATEWAY_CLIENT_ID}
     client-secret: ${GATEWAY_CLIENT_SECRET}
+    jwks-endpoint: ${application.gateway.host}/issuing/.well-known/openid-configuration/jwks
     issuing:
-      par-endpoint: https://${application.gateway.host}/issuing/par
-      authorize-endpoint: https://${application.gateway.host}/issuing/authorize?client_id=${application.gateway.client-id}
-      token-endpoint: https://${application.gateway.host}/issuing/token
+      par-endpoint: ${application.gateway.host}/issuing/par
+      authorize-endpoint: ${application.gateway.host}/issuing/authorize?client_id=${application.gateway.client-id}
+      token-endpoint: ${application.gateway.host}/issuing/token
       token:
-        audience: https://${application.gateway.host}/issuing
+        audience: ${application.gateway.host}/issuing
         issuer: ${application.gateway.client-id}
         signing-key: ${GATEWAY_TOKEN_SIGNING_KEY}
       redirect-uri: ${GATEWAY_ISSUING_REDIRECT_URI}
     verification:
-      authorize-endpoint: https://${application.gateway.host}/connect/authorize?client_id=${application.gateway.client-id}&response_type=code&redirect_uri=${application.gateway.verification.redirect-uri}&response_mode=query
-      token-endpoint: https://${application.gateway.host}/connect/token
+      authorize-endpoint: ${application.gateway.host}/connect/authorize?client_id=${application.gateway.client-id}&response_type=code&redirect_uri=${application.gateway.verification.redirect-uri}&response_mode=query
+      token-endpoint: ${application.gateway.host}/connect/token
       redirect-uri: ${GATEWAY_VERIFICATION_REDIRECT_URI}
   signature:
     secret-key: ${SIGNATURE_SECRET_KEY}

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegateIntegrationTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegateIntegrationTest.java
@@ -24,6 +24,8 @@ package uk.nhs.hee.tis.trainee.credentials.service;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 import java.security.PublicKey;
 import java.time.LocalDate;
 import java.util.Optional;
@@ -179,7 +181,7 @@ class CachingDelegateIntegrationTest {
   @Test
   void shouldReturnCachedPublicKeyAfterCaching() {
     String certificateThumbprint = UUID.randomUUID().toString();
-    PublicKey publicKey = new TestPublicKey();
+    PublicKey publicKey = Keys.keyPairFor(SignatureAlgorithm.RS256).getPublic();
     PublicKey cachedKey = delegate.cachePublicKey(certificateThumbprint, publicKey);
     assertThat("Unexpected cached value.", cachedKey, is(publicKey));
   }
@@ -187,7 +189,7 @@ class CachingDelegateIntegrationTest {
   @Test
   void shouldGetCachedPublicKeyWhenCached() {
     String certificateThumbprint = UUID.randomUUID().toString();
-    PublicKey publicKey = new TestPublicKey();
+    PublicKey publicKey = Keys.keyPairFor(SignatureAlgorithm.RS256).getPublic();
     delegate.cachePublicKey(certificateThumbprint, publicKey);
 
     Optional<PublicKey> cachedOptional = delegate.getPublicKey(certificateThumbprint);
@@ -197,7 +199,7 @@ class CachingDelegateIntegrationTest {
   @Test
   void shouldNotRemovePublicKeyWhenRetrieved() {
     String certificateThumbprint = UUID.randomUUID().toString();
-    PublicKey publicKey = new TestPublicKey();
+    PublicKey publicKey = Keys.keyPairFor(SignatureAlgorithm.RS256).getPublic();
     delegate.cachePublicKey(certificateThumbprint, publicKey);
 
     // Ignore this result, the cached value should not be evicted.
@@ -282,33 +284,5 @@ class CachingDelegateIntegrationTest {
 
     Optional<String> cachedOptional = delegate.getVerifiedSessionIdentifier(verifiedSession);
     assertThat("Unexpected cached value.", cachedOptional, is(Optional.of(verifiedSession)));
-  }
-
-  /**
-   * A {@link PublicKey} implementation to use for testing.
-   */
-  private static class TestPublicKey implements PublicKey {
-
-    private final UUID uuid = UUID.randomUUID();
-
-    @Override
-    public String getAlgorithm() {
-      return null;
-    }
-
-    @Override
-    public String getFormat() {
-      return null;
-    }
-
-    @Override
-    public byte[] getEncoded() {
-      return new byte[0];
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-      return obj instanceof TestPublicKey && this.uuid.equals(((TestPublicKey) obj).uuid);
-    }
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegateIntegrationTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegateIntegrationTest.java
@@ -24,6 +24,7 @@ package uk.nhs.hee.tis.trainee.credentials.service;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.security.PublicKey;
 import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
@@ -169,6 +170,44 @@ class CachingDelegateIntegrationTest {
   }
 
   @Test
+  void shouldReturnEmptyPublicKeyWhenNotCached() {
+    String certificateThumbprint = UUID.randomUUID().toString();
+    Optional<PublicKey> cachedOptional = delegate.getPublicKey(certificateThumbprint);
+    assertThat("Unexpected cached value.", cachedOptional, is(Optional.empty()));
+  }
+
+  @Test
+  void shouldReturnCachedPublicKeyAfterCaching() {
+    String certificateThumbprint = UUID.randomUUID().toString();
+    PublicKey publicKey = new TestPublicKey();
+    PublicKey cachedKey = delegate.cachePublicKey(certificateThumbprint, publicKey);
+    assertThat("Unexpected cached value.", cachedKey, is(publicKey));
+  }
+
+  @Test
+  void shouldGetCachedPublicKeyWhenCached() {
+    String certificateThumbprint = UUID.randomUUID().toString();
+    PublicKey publicKey = new TestPublicKey();
+    delegate.cachePublicKey(certificateThumbprint, publicKey);
+
+    Optional<PublicKey> cachedOptional = delegate.getPublicKey(certificateThumbprint);
+    assertThat("Unexpected cached value.", cachedOptional, is(Optional.of(publicKey)));
+  }
+
+  @Test
+  void shouldNotRemovePublicKeyWhenRetrieved() {
+    String certificateThumbprint = UUID.randomUUID().toString();
+    PublicKey publicKey = new TestPublicKey();
+    delegate.cachePublicKey(certificateThumbprint, publicKey);
+
+    // Ignore this result, the cached value should not be evicted.
+    delegate.getPublicKey(certificateThumbprint);
+
+    Optional<PublicKey> cachedOptional = delegate.getPublicKey(certificateThumbprint);
+    assertThat("Unexpected cached value.", cachedOptional, is(Optional.of(publicKey)));
+  }
+
+  @Test
   void shouldReturnEmptyUnverifiedSessionWhenNotCached() {
     UUID key = UUID.randomUUID();
 
@@ -238,10 +277,38 @@ class CachingDelegateIntegrationTest {
     String verifiedSession = UUID.randomUUID().toString();
     delegate.cacheVerifiedSessionIdentifier(verifiedSession);
 
-    // Ignore this result, the cached value should be evicted.
+    // Ignore this result, the cached value should not be evicted.
     delegate.getVerifiedSessionIdentifier(verifiedSession);
 
     Optional<String> cachedOptional = delegate.getVerifiedSessionIdentifier(verifiedSession);
     assertThat("Unexpected cached value.", cachedOptional, is(Optional.of(verifiedSession)));
+  }
+
+  /**
+   * A {@link PublicKey} implementation to use for testing.
+   */
+  private static class TestPublicKey implements PublicKey {
+
+    private final UUID uuid = UUID.randomUUID();
+
+    @Override
+    public String getAlgorithm() {
+      return null;
+    }
+
+    @Override
+    public String getFormat() {
+      return null;
+    }
+
+    @Override
+    public byte[] getEncoded() {
+      return new byte[0];
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj instanceof TestPublicKey && this.uuid.equals(((TestPublicKey) obj).uuid);
+    }
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegateTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegateTest.java
@@ -23,7 +23,9 @@ package uk.nhs.hee.tis.trainee.credentials.service;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.spy;
 
+import java.security.PublicKey;
 import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
@@ -69,6 +71,19 @@ class CachingDelegateTest {
     IdentityDataDto identityData = new IdentityDataDto("Anthony", "Gilliam", LocalDate.now());
     IdentityDataDto returnValue = delegate.cacheIdentityData(UUID.randomUUID(), identityData);
     assertThat("Unexpected identity data.", returnValue, is(identityData));
+  }
+
+  @Test
+  void shouldReturnCachedPublicKey() {
+    PublicKey publicKey = spy(PublicKey.class);
+    PublicKey cachedPublicKey = delegate.cachePublicKey("certThumb", publicKey);
+    assertThat("Unexpected public key.", cachedPublicKey, is(publicKey));
+  }
+
+  @Test
+  void shouldGetEmptyPublicKey() {
+    Optional<PublicKey> publicKey = delegate.getPublicKey("certThumb");
+    assertThat("Unexpected public key.", publicKey, is(Optional.empty()));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegateTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegateTest.java
@@ -23,8 +23,9 @@ package uk.nhs.hee.tis.trainee.credentials.service;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.spy;
 
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 import java.security.PublicKey;
 import java.time.LocalDate;
 import java.util.Optional;
@@ -75,7 +76,7 @@ class CachingDelegateTest {
 
   @Test
   void shouldReturnCachedPublicKey() {
-    PublicKey publicKey = spy(PublicKey.class);
+    PublicKey publicKey = Keys.keyPairFor(SignatureAlgorithm.RS256).getPublic();
     PublicKey cachedPublicKey = delegate.cachePublicKey("certThumb", publicKey);
     assertThat("Unexpected public key.", cachedPublicKey, is(publicKey));
   }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayServiceTest.java
@@ -61,7 +61,9 @@ class GatewayServiceTest {
 
   private static final String CLIENT_ID = "client-id";
   private static final String CLIENT_SECRET = "no-very-secret";
+  private static final String HOST = "https://credential.gateway";
   private static final String AUTHORIZE_ENDPOINT = "https://credential.gateway/authorize/endpoint";
+  private static final String JWKS_ENDPOINT = "https://credential.gateway/jwks/endpoint";
   private static final String PAR_ENDPOINT = "https://credential.gateway/par/endpoint";
   private static final String TOKEN_ENDPOINT = "https://credential.gateway/token/endpoint";
   private static final String REDIRECT_URI = "https://redirect.uri";
@@ -80,8 +82,8 @@ class GatewayServiceTest {
     IssuingProperties issuingProperties = new IssuingProperties(PAR_ENDPOINT, AUTHORIZE_ENDPOINT,
         "", null, REDIRECT_URI);
     VerificationProperties verificationProperties = new VerificationProperties("", "", "");
-    GatewayProperties gatewayProperties = new GatewayProperties(CLIENT_ID, CLIENT_SECRET,
-        issuingProperties, verificationProperties);
+    GatewayProperties gatewayProperties = new GatewayProperties(HOST, CLIENT_ID, CLIENT_SECRET,
+        JWKS_ENDPOINT, issuingProperties, verificationProperties);
 
     service = new GatewayService(restTemplate, jwtService, gatewayProperties);
   }
@@ -324,7 +326,7 @@ class GatewayServiceTest {
     var response = ResponseEntity.ok().body(new TokenResponse(token));
     when(restTemplate.postForEntity(eq(tokenEndpoint), any(), eq(TokenResponse.class))).thenReturn(
         response);
-    when(jwtService.getClaims(token)).thenReturn(new DefaultClaims(Map.of(
+    when(jwtService.getClaims(token, true)).thenReturn(new DefaultClaims(Map.of(
         "claim1", "value1",
         "claim2", "value2"
     )));

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/PublicKeyResolverTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/PublicKeyResolverTest.java
@@ -1,0 +1,236 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.impl.DefaultClaims;
+import io.jsonwebtoken.impl.DefaultJwsHeader;
+import io.jsonwebtoken.security.Keys;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.security.KeyPair;
+import java.security.PublicKey;
+import java.security.cert.CertificateException;
+import java.sql.Date;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.web.client.RestTemplate;
+import org.testcontainers.shaded.org.bouncycastle.asn1.ASN1Sequence;
+import org.testcontainers.shaded.org.bouncycastle.asn1.x500.X500Name;
+import org.testcontainers.shaded.org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.testcontainers.shaded.org.bouncycastle.cert.X509CertificateHolder;
+import org.testcontainers.shaded.org.bouncycastle.cert.X509v1CertificateBuilder;
+import org.testcontainers.shaded.org.bouncycastle.operator.ContentSigner;
+import org.testcontainers.shaded.org.bouncycastle.operator.OperatorCreationException;
+import org.testcontainers.shaded.org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties;
+import uk.nhs.hee.tis.trainee.credentials.service.PublicKeyResolver.Jwks;
+import uk.nhs.hee.tis.trainee.credentials.service.PublicKeyResolver.Jwks.Jwk;
+
+class PublicKeyResolverTest {
+
+  private static final String HOST = "https://credential.gateway";
+  private static final String JWKS_ENDPOINT = "https://credential.gateway/.well-known/openid-configuration/jwks";
+
+  private static final String CERTIFICATE_THUMBPRINT = "cert-thumb";
+
+  private PublicKeyResolver resolver;
+  private CachingDelegate cachingDelegate;
+  private RestTemplate restTemplate;
+
+  @BeforeEach
+  void setUp() {
+    cachingDelegate = spy(CachingDelegate.class);
+    restTemplate = mock(RestTemplate.class);
+
+    GatewayProperties properties = new GatewayProperties(HOST, "", "", JWKS_ENDPOINT, null, null);
+    resolver = new PublicKeyResolver(cachingDelegate, restTemplate, properties);
+  }
+
+  @Test
+  void shouldThrowExceptionWhenNoCertificateThumbprint() {
+    DefaultJwsHeader header = new DefaultJwsHeader();
+    Claims claims = new DefaultClaims().setIssuer(HOST);
+
+    assertThrows(IllegalArgumentException.class, () -> resolver.resolveSigningKey(header, claims));
+    verifyNoInteractions(restTemplate);
+  }
+
+  @Test
+  void shouldReturnCachedValueWhenPublicKeyCached() {
+    DefaultJwsHeader header = new DefaultJwsHeader(Map.of(
+        JwsHeader.X509_CERT_SHA1_THUMBPRINT, CERTIFICATE_THUMBPRINT));
+    Claims claims = new DefaultClaims().setIssuer(HOST);
+
+    PublicKey cachedKey = Keys.keyPairFor(SignatureAlgorithm.RS256).getPublic();
+    when(cachingDelegate.getPublicKey(CERTIFICATE_THUMBPRINT)).thenReturn(Optional.of(cachedKey));
+
+    Key key = resolver.resolveSigningKey(header, claims);
+
+    assertThat("Unexpected resolved signing key.", key, is(cachedKey));
+    verifyNoInteractions(restTemplate);
+  }
+
+  @Test
+  void shouldGetWellKnownPublicKeyWhenPublicKeyNotCached()
+      throws IOException, OperatorCreationException {
+    DefaultJwsHeader header = new DefaultJwsHeader(Map.of(
+        JwsHeader.X509_CERT_SHA1_THUMBPRINT, CERTIFICATE_THUMBPRINT));
+    Claims claims = new DefaultClaims().setIssuer(HOST);
+
+    KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.RS256);
+    String x5c = generateValidX5c(keyPair, SignatureAlgorithm.RS256);
+    Jwk jwk = new Jwk("", "", "", "", new String[]{x5c}, CERTIFICATE_THUMBPRINT, "", "");
+    when(restTemplate.getForObject(JWKS_ENDPOINT, Jwks.class)).thenReturn(new Jwks(new Jwk[]{jwk}));
+
+    Key resolvedKey = resolver.resolveSigningKey(header, claims);
+    assertThat("Unexpected resolved signing key.", resolvedKey, is(keyPair.getPublic()));
+  }
+
+  @Test
+  void shouldCachePublicKeyWhenRetrievedFromWellKnown()
+      throws IOException, OperatorCreationException {
+    DefaultJwsHeader header = new DefaultJwsHeader(Map.of(
+        JwsHeader.X509_CERT_SHA1_THUMBPRINT, CERTIFICATE_THUMBPRINT));
+    Claims claims = new DefaultClaims().setIssuer(HOST);
+
+    KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.RS256);
+    String x5c = generateValidX5c(keyPair, SignatureAlgorithm.RS256);
+    Jwk jwk = new Jwk("", "", "", "", new String[]{x5c}, CERTIFICATE_THUMBPRINT, "", "");
+    when(restTemplate.getForObject(JWKS_ENDPOINT, Jwks.class)).thenReturn(new Jwks(new Jwk[]{jwk}));
+
+    resolver.resolveSigningKey(header, claims);
+    verify(cachingDelegate).cachePublicKey(CERTIFICATE_THUMBPRINT, keyPair.getPublic());
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = "https://not.credential.gateway")
+  void shouldThrowExceptionWhenIssuerNotMatchesHost(String issuer) {
+    DefaultJwsHeader header = new DefaultJwsHeader(Map.of(
+        JwsHeader.X509_CERT_SHA1_THUMBPRINT, CERTIFICATE_THUMBPRINT));
+    Claims claims = new DefaultClaims().setIssuer(issuer);
+
+    assertThrows(IllegalArgumentException.class, () -> resolver.resolveSigningKey(header, claims));
+    verifyNoInteractions(restTemplate);
+  }
+
+  @Test
+  void shouldThrowExceptionWhenJwksEndpointReturnsNull() {
+    DefaultJwsHeader header = new DefaultJwsHeader(Map.of(
+        JwsHeader.X509_CERT_SHA1_THUMBPRINT, CERTIFICATE_THUMBPRINT));
+    Claims claims = new DefaultClaims().setIssuer(HOST);
+
+    when(restTemplate.getForObject(JWKS_ENDPOINT, Jwks.class)).thenReturn(null);
+
+    assertThrows(IllegalArgumentException.class, () -> resolver.resolveSigningKey(header, claims));
+  }
+
+  @Test
+  void shouldThrowExceptionWhenJwksEndpointReturnsNoKeys() {
+    DefaultJwsHeader header = new DefaultJwsHeader(Map.of(
+        JwsHeader.X509_CERT_SHA1_THUMBPRINT, CERTIFICATE_THUMBPRINT));
+    Claims claims = new DefaultClaims().setIssuer(HOST);
+
+    when(restTemplate.getForObject(JWKS_ENDPOINT, Jwks.class)).thenReturn(new Jwks(new Jwk[0]));
+
+    assertThrows(IllegalArgumentException.class, () -> resolver.resolveSigningKey(header, claims));
+  }
+
+  @Test
+  void shouldThrowExceptionWhenJwksEndpointReturnsNoMatchingKeys() {
+    DefaultJwsHeader header = new DefaultJwsHeader(Map.of(
+        JwsHeader.X509_CERT_SHA1_THUMBPRINT, CERTIFICATE_THUMBPRINT));
+    Claims claims = new DefaultClaims().setIssuer(HOST);
+
+    Jwk jwk = new Jwk("", "", "", "", null, "not-cert-thumb", "", "");
+    when(restTemplate.getForObject(JWKS_ENDPOINT, Jwks.class)).thenReturn(new Jwks(new Jwk[]{jwk}));
+
+    assertThrows(IllegalArgumentException.class, () -> resolver.resolveSigningKey(header, claims));
+  }
+
+  @Test
+  void shouldThrowExceptionWhenJwksEndpointReturnsInvalidCertificate() {
+    DefaultJwsHeader header = new DefaultJwsHeader(Map.of(
+        JwsHeader.X509_CERT_SHA1_THUMBPRINT, CERTIFICATE_THUMBPRINT));
+    Claims claims = new DefaultClaims().setIssuer(HOST);
+
+    String x5c = Base64.getEncoder()
+        .encodeToString("invalid-certificate".getBytes(StandardCharsets.UTF_8));
+    Jwk jwk = new Jwk("", "", "", "", new String[]{x5c}, CERTIFICATE_THUMBPRINT, "", "");
+    when(restTemplate.getForObject(JWKS_ENDPOINT, Jwks.class)).thenReturn(new Jwks(new Jwk[]{jwk}));
+
+    Throwable cause = assertThrows(IllegalArgumentException.class,
+        () -> resolver.resolveSigningKey(header, claims)).getCause();
+    assertThat("Unexpected exception cause.", cause,
+        CoreMatchers.instanceOf(CertificateException.class));
+  }
+
+  /**
+   * Generate a valid self-signed certificate to use as a JWKs x5c cert.
+   *
+   * @param keyPair The key pair to use for generating a x5c certificate.
+   * @param alg     The algorithm used to generate the {@link KeyPair}.
+   * @return The generated certificate.
+   */
+  private String generateValidX5c(KeyPair keyPair, SignatureAlgorithm alg)
+      throws OperatorCreationException, IOException {
+    ASN1Sequence asn1Sequence = ASN1Sequence.getInstance(keyPair.getPublic().getEncoded());
+    SubjectPublicKeyInfo subjectPublicKeyInfo = SubjectPublicKeyInfo.getInstance(asn1Sequence);
+
+    ContentSigner sigGen = new JcaContentSignerBuilder(alg.getJcaName())
+        .build(keyPair.getPrivate());
+
+    X509v1CertificateBuilder certBuilder = new X509v1CertificateBuilder(
+        new X500Name("CN=Test"),
+        BigInteger.ONE,
+        Date.from(Instant.now()),
+        Date.from(Instant.now().plus(Duration.ofHours(1))),
+        new X500Name("CN=Test"),
+        subjectPublicKeyInfo
+    );
+    X509CertificateHolder certHolder = certBuilder.build(sigGen);
+    return Base64.getEncoder().encodeToString(certHolder.getEncoded());
+  }
+}


### PR DESCRIPTION
Create a key resolver to get the public key for the token, based on the
issuer and known JWKS endpoints. The retrieved public key will be cached
for later usage to avoid having to request the key each and every time.