### PR TITLE
feat: create session verification filter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.8.0"
+version = "0.9.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/filter/FilterConfiguration.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/filter/FilterConfiguration.java
@@ -24,7 +24,6 @@ package uk.nhs.hee.tis.trainee.credentials.filter;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.Ordered;
 
 /**
  * A configuration for request filters.
@@ -45,7 +44,23 @@ public class FilterConfiguration {
 
     registrationBean.setFilter(filter);
     registrationBean.addUrlPatterns("/api/issue/*", "/api/verify/*");
-    registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE);
+
+    return registrationBean;
+  }
+
+  /**
+   * Register a {@link VerifiedSessionFilter}.
+   *
+   * @param filter The filter to register.
+   * @return The {@link FilterRegistrationBean} for the registration.
+   */
+  @Bean
+  public FilterRegistrationBean<VerifiedSessionFilter> registerVerifiedSessionFilter(
+      VerifiedSessionFilter filter) {
+    FilterRegistrationBean<VerifiedSessionFilter> registrationBean = new FilterRegistrationBean<>();
+
+    registrationBean.setFilter(filter);
+    registrationBean.addUrlPatterns("/api/issue/*");
 
     return registrationBean;
   }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/filter/VerifiedSessionFilter.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/filter/VerifiedSessionFilter.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import uk.nhs.hee.tis.trainee.credentials.service.VerificationService;
+
+/**
+ * A request filter that verifies whether the user has an identity-verified session.
+ */
+@Component
+public class VerifiedSessionFilter extends OncePerRequestFilter {
+
+  private final VerificationService verificationService;
+
+  /**
+   * Create a request filter that verifies whether the user has an identity-verified session.
+   *
+   * @param verificationService The verification service to check the session verification.
+   */
+  VerifiedSessionFilter(VerificationService verificationService) {
+    this.verificationService = verificationService;
+  }
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    String requestUri = request.getRequestURI();
+    return requestUri.endsWith("/callback");
+  }
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    if (verificationService.hasVerifiedSession(request)) {
+      filterChain.doFilter(request, response);
+    } else {
+      response.setStatus(HttpStatus.UNAUTHORIZED.value());
+      response.setHeader(HttpHeaders.WWW_AUTHENTICATE,
+          "IdentityVerification realm=\"/api/verify/identity\"");
+    }
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/PublicKeyResolver.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/PublicKeyResolver.java
@@ -34,7 +34,8 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Objects;
 import java.util.Optional;
-import lombok.Value;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties;
@@ -128,19 +129,19 @@ public class PublicKeyResolver extends SigningKeyResolverAdapter {
   /**
    * A JWKs document, with an array of JWK keys.
    */
-  @Value
+  @Data
   static class Jwks {
 
-    Jwk[] keys;
+    private Jwk[] keys;
 
     /**
      * A representation of a JWK, unused fields have been excluded for simplicity.
      */
-    @Value
+    @Data
     static class Jwk {
 
-      String[] x5c; // X.509 certificate chain.
-      String x5t; // X.509 certificate SHA-1 thumbprint.
+      private String[] x5c; // X.509 certificate chain.
+      private String x5t; // X.509 certificate SHA-1 thumbprint.
     }
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationService.java
@@ -22,6 +22,7 @@
 package uk.nhs.hee.tis.trainee.credentials.service;
 
 import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
 import java.security.SecureRandom;
 import java.time.LocalDate;
@@ -30,6 +31,7 @@ import java.util.Optional;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.springframework.http.HttpHeaders;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -211,5 +213,20 @@ public class VerificationService {
     }
 
     return false;
+  }
+
+  /**
+   * Check whether there is a verified session for the given request.
+   *
+   * @param request The request to check the session for.
+   * @return true if verified, otherwise false.
+   */
+  public boolean hasVerifiedSession(HttpServletRequest request) {
+    String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+    Claims authClaims = jwtService.getClaims(authorization);
+    String sessionId = authClaims.get(CLAIM_TOKEN_IDENTIFIER, String.class);
+    Optional<String> verifiedSession = cachingDelegate.getVerifiedSessionIdentifier(sessionId);
+
+    return verifiedSession.isPresent();
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/filter/VerifiedSessionFilterTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/filter/VerifiedSessionFilterTest.java
@@ -1,0 +1,106 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.filter;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import uk.nhs.hee.tis.trainee.credentials.service.VerificationService;
+
+class VerifiedSessionFilterTest {
+
+  private VerifiedSessionFilter filter;
+  private VerificationService verificationService;
+
+  @BeforeEach
+  void setUp() {
+    verificationService = mock(VerificationService.class);
+    this.filter = new VerifiedSessionFilter(verificationService);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"api/issue/callback", "api/verify/callback", "/callback"})
+  void shouldNotFilterCallbacks(String uri) {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRequestURI(uri);
+
+    boolean filterInactive = filter.shouldNotFilter(request);
+    assertThat("Unexpected filter activation.", filterInactive, is(true));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"api/issue/credential", "api/verify/identity", "/not-a-callback"})
+  void shouldFilterNonCallbacks(String uri) {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRequestURI(uri);
+
+    boolean filterInactive = filter.shouldNotFilter(request);
+    assertThat("Unexpected filter deactivation.", filterInactive, is(false));
+  }
+
+  @Test
+  void shouldBeUnauthorizedWhenSessionNotVerified() throws ServletException, IOException {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain filterChain = mock(FilterChain.class);
+
+    when(verificationService.hasVerifiedSession(request)).thenReturn(false);
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat("Unexpected response status.", response.getStatus(), is(401));
+    assertThat("Unexpected response status.", response.getHeader(HttpHeaders.WWW_AUTHENTICATE),
+        is("IdentityVerification realm=\"/api/verify/identity\""));
+    verifyNoInteractions(filterChain);
+  }
+
+  @Test
+  void shouldCallFilterChainWhenSessionVerified() throws ServletException, IOException {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain filterChain = mock(FilterChain.class);
+
+    when(verificationService.hasVerifiedSession(request)).thenReturn(true);
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat("Unexpected response status.", response.getStatus(), is(200));
+    verify(filterChain).doFilter(any(HttpServletRequest.class), eq(response));
+  }
+}


### PR DESCRIPTION
Create a request filter that checks whether the current request has an associated verified session. If so, requests are allowed, otherwise requests will be blocked with guidance to verify the users identity via the API.

Update the VerificationService to provide the verification functionality.

TIS21-4177
TIS21-4184