### PR TITLE
fix: Bearer token prefix breaks JWT processing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.9.0"
+version = "0.9.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/JwtService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/JwtService.java
@@ -104,6 +104,9 @@ public class JwtService {
    * @return The extracted claims.
    */
   public Claims getClaims(String token, boolean verifySignature) {
+    // Strip any Bearer prefix
+    token = token.replace("Bearer ", "");
+
     JwtParser parser = Jwts.parserBuilder().setSigningKeyResolver(publicKeyResolver).build();
 
     if (!verifySignature) {

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/JwtServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/JwtServiceTest.java
@@ -185,6 +185,25 @@ class JwtServiceTest {
   }
 
   @Test
+  void shouldHandleBearerPrefixWhenGettingClaims() throws NoSuchAlgorithmException {
+    byte[] keyBytes = new byte[32];
+    SecureRandom.getInstanceStrong().nextBytes(keyBytes);
+    SecretKey key = Keys.hmacShaKeyFor(keyBytes);
+
+    String token = Jwts.builder().signWith(key)
+        .claim("claim1", "value1")
+        .claim("claim2", "value2")
+        .compact();
+
+    Claims claims = service.getClaims("Bearer " + token);
+    assertThat("Unexpected claim count.", claims.size(), is(2));
+    assertThat("Unexpected claim value.", claims.get("claim1"), is("value1"));
+    assertThat("Unexpected claim value.", claims.get("claim2"), is("value2"));
+
+    verifyNoInteractions(signingKeyResolver);
+  }
+
+  @Test
   void shouldGetClaimsFromSignedTokenByDefault() throws NoSuchAlgorithmException {
     byte[] keyBytes = new byte[32];
     SecureRandom.getInstanceStrong().nextBytes(keyBytes);


### PR DESCRIPTION
Getting the claims from a JWT is not working if the token includes the `Bearer ` prefix. Strip any prefix before attempting to get the token's claims.

TIS21-4177