### PR TITLE
feat: draft refactoring of IssuanceService

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
   // Spring Boot starters
   implementation "org.springframework.boot:spring-boot-starter-actuator"
   implementation "org.springframework.boot:spring-boot-starter-data-redis"
+  implementation "org.springframework.boot:spring-boot-starter-data-mongodb"
   implementation "org.springframework.boot:spring-boot-starter-web"
   implementation "org.springframework.boot:spring-boot-starter-validation"
   testImplementation "org.springframework.boot:spring-boot-starter-test"

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResource.java
@@ -22,12 +22,15 @@
 package uk.nhs.hee.tis.trainee.credentials.api;
 
 import java.net.URI;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -36,7 +39,7 @@ import uk.nhs.hee.tis.trainee.credentials.dto.PlacementDataDto;
 import uk.nhs.hee.tis.trainee.credentials.dto.ProgrammeMembershipCredentialDto;
 import uk.nhs.hee.tis.trainee.credentials.dto.ProgrammeMembershipDataDto;
 import uk.nhs.hee.tis.trainee.credentials.mapper.CredentialDataMapper;
-import uk.nhs.hee.tis.trainee.credentials.service.GatewayService;
+import uk.nhs.hee.tis.trainee.credentials.service.IssuanceService;
 
 /**
  * API endpoints for issuing trainee digital credentials.
@@ -46,47 +49,53 @@ import uk.nhs.hee.tis.trainee.credentials.service.GatewayService;
 @RequestMapping("/api/issue")
 public class IssueResource {
 
-  private final GatewayService service;
+  private final IssuanceService issuanceService;
   private final CredentialDataMapper mapper;
 
-  IssueResource(GatewayService service, CredentialDataMapper mapper) {
-    this.service = service;
+  IssueResource(IssuanceService issuanceService, CredentialDataMapper mapper) {
+    this.issuanceService = issuanceService;
     this.mapper = mapper;
   }
 
   @PostMapping("/programme-membership")
   ResponseEntity<String> issueProgrammeMembershipCredential(
+      @RequestHeader(HttpHeaders.AUTHORIZATION) String token,
       @Validated @RequestBody ProgrammeMembershipDataDto dataDto,
       @RequestParam(required = false) String state) {
     log.info("Received request to issue Programme Membership credential.");
     ProgrammeMembershipCredentialDto credentialDto = mapper.toCredential(dataDto);
-    Optional<URI> credentialUri = service.getCredentialUri(credentialDto, state);
-
-    if (credentialUri.isPresent()) {
-      URI uri = credentialUri.get();
-      log.info("Programme Membership credential successfully issued.");
-      return ResponseEntity.created(uri).body(uri.toString());
-    } else {
-      log.error("Could not issue Programme Membership credential.");
-      return ResponseEntity.internalServerError().build();
-    }
+    URI uri = issuanceService.startCredentialIssuance(token, credentialDto, state);
+    return ResponseEntity.created(uri).body(uri.toString());
   }
 
   @PostMapping("/placement")
   ResponseEntity<String> issuePlacementCredential(
+      @RequestHeader(HttpHeaders.AUTHORIZATION) String token,
       @Validated @RequestBody PlacementDataDto dataDto,
       @RequestParam(required = false) String state) {
     log.info("Received request to issue Placement credential.");
     PlacementCredentialDto credentialDto = mapper.toCredential(dataDto);
-    Optional<URI> credentialUri = service.getCredentialUri(credentialDto, state);
+    URI uri = issuanceService.startCredentialIssuance(token, credentialDto, state);
+    return ResponseEntity.created(uri).body(uri.toString());
+  }
 
-    if (credentialUri.isPresent()) {
-      URI uri = credentialUri.get();
-      log.info("Placement credential successfully issued.");
-      return ResponseEntity.created(uri).body(uri.toString());
-    } else {
-      log.error("Could not issue Placement credential.");
-      return ResponseEntity.internalServerError().build();
-    }
+  /**
+   * A callback to log the outcome of the issued resource, and redirect to the redirect_uri.
+   *
+   * @param code  The code returned from the gateway.
+   * @param state The internal state returned from the gateway.
+   * @return The response entity redirecting to the issuing redirect_uri.
+   */
+  @GetMapping("/callback")
+  ResponseEntity<String> logIssuedResource(
+      @RequestParam(required = false) String code,
+      @RequestParam(required = false) String state) {
+
+    log.info("Receiving callback for credential issuing.");
+
+    URI redirectUri = issuanceService.completeCredentialIssuance(code, state);
+
+    log.info("Redirecting after credential issuing process.");
+    return ResponseEntity.status(HttpStatus.FOUND).location(redirectUri).build();
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/CacheConfiguration.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/CacheConfiguration.java
@@ -41,6 +41,7 @@ public class CacheConfiguration {
 
   public static final String VERIFICATION_REQUEST_DATA = "verificationRequestCacheManager";
   public static final String VERIFIED_SESSION_DATA = "verifiedSessionCacheManager";
+  public static final String CREDENTIAL_METADATA = "credentialMetadataCacheManager";
 
   private final CacheProperties properties;
 
@@ -80,6 +81,17 @@ public class CacheConfiguration {
   @Bean
   public CacheManager verifiedSessionCacheManager(RedisConnectionFactory factory) {
     return buildCacheManager(factory, properties.timeToLive().verifiedSession());
+  }
+
+  /**
+   * Create a cache manager for credential metadata caching.
+   *
+   * @param factory The Redis connection factory.
+   * @return The built cache manager.
+   */
+  @Bean
+  public CacheManager credentialMetadataCacheManager(RedisConnectionFactory factory) {
+    return buildCacheManager(factory, properties.timeToLive().credentialMetadata());
   }
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/CacheProperties.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/CacheProperties.java
@@ -38,10 +38,15 @@ public record CacheProperties(String keyPrefix, TimeToLiveProperties timeToLive)
   /**
    * A representation of the application cache time-to-live properties.
    *
+   * @param credentialMetadata  The time-to-live for credential metadata.
    * @param verificationRequest The time-to-live for verification request data.
    * @param verifiedSession     The time-to-live for verified session data.
    */
   public record TimeToLiveProperties(
+
+      @DurationUnit(ChronoUnit.SECONDS)
+      Duration credentialMetadata,
+
       @DurationUnit(ChronoUnit.SECONDS)
       Duration verificationRequest,
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/GatewayProperties.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/GatewayProperties.java
@@ -51,6 +51,7 @@ public record GatewayProperties(
    * @param token             The issuing token child properties.
    * @param redirectUri       The URI to redirect to after issuing a credential.
    */
+  @ConfigurationProperties(prefix = "application.gateway.issuing")
   public record IssuingProperties(
       String parEndpoint,
       String authorizeEndpoint,

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/CredentialDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/CredentialDto.java
@@ -22,12 +22,20 @@
 package uk.nhs.hee.tis.trainee.credentials.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.io.Serializable;
 import java.time.Instant;
 
 /**
  * An interface representing a DTO containing credential data.
  */
-public interface CredentialDto {
+public interface CredentialDto extends Serializable {
+
+  /**
+   * Get the TIS ID of the record, which is recorded in the credential metadata, not the credential
+   * itself.
+   */
+  @JsonIgnore
+  String getTisId();
 
   /**
    * Get the expiry instant for the credential.

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/PlacementCredentialDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/PlacementCredentialDto.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.tis.trainee.credentials.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -39,6 +40,9 @@ import java.time.ZoneOffset;
  * @param endDate            The placement's end date.
  */
 public record PlacementCredentialDto(
+    @JsonIgnore
+    String tisId,
+
     @JsonProperty("TPL-Specialty")
     String specialty,
 
@@ -69,5 +73,10 @@ public record PlacementCredentialDto(
   @Override
   public String getScope() {
     return "issue.TrainingPlacement";
+  }
+
+  @Override
+  public String getTisId() {
+    return tisId();
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/filter/FilterConfiguration.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/filter/FilterConfiguration.java
@@ -60,7 +60,7 @@ public class FilterConfiguration {
     FilterRegistrationBean<VerifiedSessionFilter> registrationBean = new FilterRegistrationBean<>();
 
     registrationBean.setFilter(filter);
-    registrationBean.addUrlPatterns("/api/issue/*");
+    registrationBean.addUrlPatterns("/api/issue/skip/*");
 
     return registrationBean;
   }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/model/CredentialMetadata.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/model/CredentialMetadata.java
@@ -19,48 +19,33 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.trainee.credentials.dto;
+package uk.nhs.hee.tis.trainee.credentials.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
+
+import java.io.Serializable;
 import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.ZoneOffset;
+import lombok.Data;
+import org.springframework.context.annotation.Scope;
+import org.springframework.data.annotation.Id;
+import org.springframework.stereotype.Component;
 
 /**
- * A DTO representing a Programme Membership credential.
- *
- * @param programmeName The programme name.
- * @param startDate     The programme's start date.
- * @param endDate       The programme's end date.
+ * A credential metadata record with all properties needed to store permenently.
  */
-public record ProgrammeMembershipCredentialDto(
-    @JsonIgnore
-    String tisId,
+@Component(CredentialMetadata.ENTITY_NAME)
+@Scope(SCOPE_PROTOTYPE)
+@Data
+public class CredentialMetadata implements Serializable {
 
-    @JsonProperty("TPR-Name")
-    String programmeName,
+  public static final String ENTITY_NAME = "CredentialMetadata";
 
-    @JsonProperty("TPR-ProgrammeStartDate")
-    LocalDate startDate,
+  @Id
+  private String credentialId;
 
-    @JsonProperty("TPR-ProgrammeEndDate")
-    LocalDate endDate
-) implements CredentialDto {
-
-  @Override
-  public Instant getExpiration(Instant issuedAt) {
-    return endDate.atTime(LocalTime.MAX).toInstant(ZoneOffset.UTC);
-  }
-
-  @Override
-  public String getScope() {
-    return "issue.TrainingProgramme";
-  }
-
-  @Override
-  public String getTisId() {
-    return tisId();
-  }
+  private String traineeId;
+  private String credentialType;
+  private String tisId;
+  private Instant issuedAt;
+  private Instant expiresAt;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/repository/CredentialMetadataRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/repository/CredentialMetadataRepository.java
@@ -19,48 +19,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.trainee.credentials.dto;
+package uk.nhs.hee.tis.trainee.credentials.repository;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.ZoneOffset;
+import java.util.Optional;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+import uk.nhs.hee.tis.trainee.credentials.model.CredentialMetadata;
 
 /**
- * A DTO representing a Programme Membership credential.
- *
- * @param programmeName The programme name.
- * @param startDate     The programme's start date.
- * @param endDate       The programme's end date.
+ * A repository for credential metadata log records.
  */
-public record ProgrammeMembershipCredentialDto(
-    @JsonIgnore
-    String tisId,
-
-    @JsonProperty("TPR-Name")
-    String programmeName,
-
-    @JsonProperty("TPR-ProgrammeStartDate")
-    LocalDate startDate,
-
-    @JsonProperty("TPR-ProgrammeEndDate")
-    LocalDate endDate
-) implements CredentialDto {
+@Repository
+public interface CredentialMetadataRepository extends MongoRepository<CredentialMetadata, String> {
 
   @Override
-  public Instant getExpiration(Instant issuedAt) {
-    return endDate.atTime(LocalTime.MAX).toInstant(ZoneOffset.UTC);
-  }
+  Optional<CredentialMetadata> findById(String id);
 
   @Override
-  public String getScope() {
-    return "issue.TrainingProgramme";
-  }
+  <T extends CredentialMetadata> T save(T entity);
 
   @Override
-  public String getTisId() {
-    return tisId();
-  }
+  void deleteById(String id);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegate.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegate.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.tis.trainee.credentials.service;
 
+import static uk.nhs.hee.tis.trainee.credentials.config.CacheConfiguration.CREDENTIAL_METADATA;
 import static uk.nhs.hee.tis.trainee.credentials.config.CacheConfiguration.VERIFICATION_REQUEST_DATA;
 import static uk.nhs.hee.tis.trainee.credentials.config.CacheConfiguration.VERIFIED_SESSION_DATA;
 
@@ -31,6 +32,7 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDto;
 import uk.nhs.hee.tis.trainee.credentials.dto.IdentityDataDto;
 
 /**
@@ -42,8 +44,10 @@ class CachingDelegate {
 
   private static final String CLIENT_STATE = "ClientState";
   private static final String CODE_VERIFIER = "CodeVerifier";
+  private static final String CREDENTIAL_DATA = "CredentialData";
   private static final String IDENTITY_DATA = "IdentityData";
   private static final String PUBLIC_KEY = "PublicKey";
+  private static final String TRAINEE_ID = "TraineeIdentifier";
   private static final String UNVERIFIED_SESSION_IDENTIFIER = "SessionIdentifier::Unverified";
   private static final String VERIFIED_SESSION_IDENTIFIER = "SessionIdentifier::Verified";
 
@@ -68,6 +72,30 @@ class CachingDelegate {
   @Cacheable(cacheNames = CODE_VERIFIER, cacheManager = VERIFICATION_REQUEST_DATA)
   @CacheEvict(CODE_VERIFIER)
   public Optional<String> getCodeVerifier(UUID key) {
+    return Optional.empty();
+  }
+
+  /**
+   * Cache an credential data dto for later retrieval.
+   *
+   * @param key The cache key.
+   * @param dto The credential data to cache.
+   * @return The cached credential data.
+   */
+  @CachePut(cacheNames = CREDENTIAL_DATA, cacheManager = CREDENTIAL_METADATA, key = "#key")
+  public CredentialDto cacheCredentialData(UUID key, CredentialDto dto) {
+    return dto;
+  }
+
+  /**
+   * Get the credential data associated with the given key, any cached value will be removed.
+   *
+   * @param key The cache key.
+   * @return The cached credential data, or an empty optional if not found.
+   */
+  @Cacheable(cacheNames = CREDENTIAL_DATA, cacheManager = CREDENTIAL_METADATA)
+  @CacheEvict(CREDENTIAL_DATA)
+  public Optional<CredentialDto> getCredentialData(UUID key) {
     return Optional.empty();
   }
 
@@ -139,6 +167,30 @@ class CachingDelegate {
    */
   @Cacheable(cacheNames = PUBLIC_KEY)
   public Optional<PublicKey> getPublicKey(String certificateThumbprint) {
+    return Optional.empty();
+  }
+
+  /**
+   * Cache a trainee identifier for later retrieval.
+   *
+   * @param key               The cache key.
+   * @param traineeIdentifier The trainee identifier to cache.
+   * @return The cached trainee identifier.
+   */
+  @CachePut(cacheNames = TRAINEE_ID, cacheManager = CREDENTIAL_METADATA, key = "#key")
+  public String cacheTraineeIdentifier(UUID key, String traineeIdentifier) {
+    return traineeIdentifier;
+  }
+
+  /**
+   * Get the trainee identifier associated with the given key, any cached value will be removed.
+   *
+   * @param key The cache key.
+   * @return The cached trainee identifier, or an empty optional if not found.
+   */
+  @Cacheable(cacheNames = TRAINEE_ID, cacheManager = CREDENTIAL_METADATA)
+  @CacheEvict(TRAINEE_ID)
+  public Optional<String> getTraineeIdentifier(UUID key) {
     return Optional.empty();
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayService.java
@@ -73,8 +73,8 @@ public class GatewayService {
    * @param state The client state.
    * @return The URI to issue the credential.
    */
-  public Optional<URI> getCredentialUri(CredentialDto dto, String state) {
-    HttpEntity<MultiValueMap<String, String>> request = buildParRequest(dto, state);
+  public Optional<URI> getCredentialUri(CredentialDto dto, String nonce, String state) {
+    HttpEntity<MultiValueMap<String, String>> request = buildParRequest(dto, nonce, state);
 
     log.info("Sending PAR request.");
     ResponseEntity<ParResponse> response = restTemplate.postForEntity(
@@ -92,11 +92,10 @@ public class GatewayService {
    * @return The built request.
    */
   private HttpEntity<MultiValueMap<String, String>> buildParRequest(CredentialDto dto,
-      String state) {
+      String nonce, String state) {
     log.info("Building PAR request.");
     String idTokenHint = jwtService.generateToken(dto);
 
-    String nonce = UUID.randomUUID().toString();
     MultiValueMap<String, String> bodyPair = new LinkedMultiValueMap<>();
     bodyPair.add("client_id", properties.clientId());
     bodyPair.add("client_secret", properties.clientSecret());

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/IssuanceService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/IssuanceService.java
@@ -1,0 +1,115 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.service;
+
+import io.jsonwebtoken.Claims;
+import java.net.URI;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties.IssuingProperties;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDto;
+import uk.nhs.hee.tis.trainee.credentials.model.CredentialMetadata;
+import uk.nhs.hee.tis.trainee.credentials.repository.CredentialMetadataRepository;
+
+@Service
+public class IssuanceService {
+
+  private final GatewayService gatewayService;
+  private final JwtService jwtService;
+  private final CachingDelegate cachingDelegate;
+  private final CredentialMetadataRepository repository;
+  private final IssuingProperties properties;
+
+  IssuanceService(GatewayService gatewayService, JwtService jwtService, CachingDelegate cachingDelegate, CredentialMetadataRepository repository, IssuingProperties properties) {
+    this.gatewayService = gatewayService;
+    this.jwtService = jwtService;
+    this.cachingDelegate = cachingDelegate;
+    this.repository = repository;
+    this.properties = properties;
+  }
+
+  public URI startCredentialIssuance(String authToken, CredentialDto dto, @Nullable String clientState) {
+    // Cache the provided identity data against the nonce.
+    UUID nonce = UUID.randomUUID();
+    cachingDelegate.cacheCredentialData(nonce, dto);
+
+    // Generate new state for the internal request/callback and cache the client state.
+    UUID internalState = UUID.randomUUID();
+    cachingDelegate.cacheClientState(internalState, clientState);
+
+    // Cache an ID from the token to represent the session.
+    Claims authClaims = jwtService.getClaims(authToken);
+    String traineeId = authClaims.get("custom:tisId", String.class);
+    cachingDelegate.cacheTraineeIdentifier(internalState, traineeId);
+
+    return gatewayService.getCredentialUri(dto, nonce.toString(), internalState.toString()).get();
+  }
+
+  public URI completeCredentialIssuance(String code, String state) {
+    UUID stateUuid = UUID.fromString(state);
+    Optional<String> traineeId = cachingDelegate.getTraineeIdentifier(stateUuid);
+    String failureCode = null;
+
+    if (traineeId.isEmpty()) {
+      failureCode = "invalid_state";
+    } else {
+      URI tokenEndpoint = URI.create(properties.tokenEndpoint());
+      URI redirectEndpoint = URI.create(properties.redirectUri());
+      Claims claims = gatewayService.getTokenClaims(tokenEndpoint, redirectEndpoint, code, null);
+
+      UUID nonce = UUID.fromString(claims.get("nonce", String.class));
+      Optional<CredentialDto> credentialData = cachingDelegate.getCredentialData(nonce);
+
+      if (credentialData.isEmpty()) {
+        failureCode = "invalid_nonce";
+      } else {
+        CredentialDto credentialDto = credentialData.get();
+
+        CredentialMetadata metadata = new CredentialMetadata();
+        metadata.setTisId(credentialDto.getTisId());
+        metadata.setCredentialType(credentialDto.getScope());
+        metadata.setTraineeId(traineeId.get());
+        metadata.setCredentialId(claims.get("SerialNumber", String.class));
+        metadata.setIssuedAt(claims.getIssuedAt().toInstant());
+        metadata.setExpiresAt(claims.getExpiration().toInstant());
+
+        repository.save(metadata);
+      }
+    }
+
+    UriComponentsBuilder uriBuilder;
+
+    if (failureCode == null) {
+      uriBuilder = UriComponentsBuilder.fromUriString("/credential-issued");
+    } else {
+      uriBuilder = UriComponentsBuilder.fromUriString("/invalid-credential")
+          .queryParam("reason", failureCode);
+    }
+
+    Optional<String> clientState = cachingDelegate.getClientState(stateUuid);
+    uriBuilder.queryParamIfPresent("state", clientState);
+    return uriBuilder.build().toUri();
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationService.java
@@ -179,7 +179,7 @@ public class VerificationService {
     }
 
     Optional<String> clientState = cachingDelegate.getClientState(stateUuid);
-    clientState.ifPresent(s -> uriBuilder.queryParam("state", s));
+    uriBuilder.queryParamIfPresent("state", clientState);
     return uriBuilder.build().toUri();
   }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,7 @@ application:
     time-to-live:
       verification-request: ${REDIS_TTL_VERIFICATION_REQUEST:300}
       verified-session: ${REDIS_TTL_VERIFIED_SESSION:600}
+      credential-metadata: ${REDIS_TTL_ISSUING_FLOW:600}
   gateway:
     host: https://${GATEWAY_HOST}
     client-id: ${GATEWAY_CLIENT_ID}
@@ -36,6 +37,8 @@ sentry:
 
 spring:
   data:
+    mongodb:
+      uri: mongodb://${DB_USER:admin}:${DB_PASSWORD:pwd}@${DB_HOST:localhost}:${DB_PORT:27017}/${DB_NAME:credentials}?authSource=${AUTH_SOURCE:admin}&readPreference=secondaryPreferred
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,5 +4,6 @@ application:
     time-to-live:
       verification-request: 60
       verified-session: 60
+      credential-metadata: 60
   signature:
     secret-key: test-secret-key


### PR DESCRIPTION
An incomplete refactoring of #24

Notable differences beyond just shuffling code around (some intentional, some laziness):
 - `IssueRequestDto` removed, the original `CredentialDto` is cached instead of the `IssueRequestDto`
 - `IssuedResponseDto` removed, the `CredentialMetadata` is built directly from individual properties (not ideal)
 - `CredentialMetadataMapper` removed, without the above DTOs it wasn't useful but needs to be brought back with sensible sources
 - `LocalDateTime` changed to `Instant` for `iss` and `exp`, Instant is a universal point in time instead of LocalDateTime changing per time zone.
 - Trainee ID cached during initial issue request, it's the only time we have the auth token.
 - Callback URI property removed, hardcoded to a relative URI e.g. `/credential-issued`, same as verification
 - Gateway errors are ignored (laziness), we'll just end up with a generic error from our side - probably need a wider look at error handling/messaging (both issue and verify) once we start frontend work
 - Includes a hacky disabling of the `SignedDataFilter` to make local testing a bit easier
 - No tests included, some won't compile, others will fail.



TIS21-4110