### PR TITLE
fix: key not resolved for issued tokens

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.9.1"
+version = "0.9.2"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationService.java
@@ -179,7 +179,7 @@ public class VerificationService {
     }
 
     Optional<String> clientState = cachingDelegate.getClientState(stateUuid);
-    clientState.ifPresent(s -> uriBuilder.queryParam("state", s));
+    uriBuilder.queryParamIfPresent("state", clientState);
     return uriBuilder.build().toUri();
   }
 


### PR DESCRIPTION
The public key resolver expects a token header to have `x5t` set and the issuer to be `<gateway-host>`.
This works for verification tokens, but not issued tokens. Issued tokens do not include the `x5t` header and the issuer is
`<gateway-host>/issuing`.

Rewrite the `PublicKeyResolver` to use the `kid` (key id), `n` (modulus) and `e` (exponent) headers to determine the public key. The verification token's key id is formatted as `<kid><alg>` where as the issued token is simply `<kid>` so extra manipulation is needed to ensure consistent retrieval and caching of the key.

TIS21-4110