### PR TITLE
Refactor/issue callback

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegate.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegate.java
@@ -32,6 +32,7 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDto;
 import uk.nhs.hee.tis.trainee.credentials.dto.IdentityDataDto;
 import uk.nhs.hee.tis.trainee.credentials.dto.IssueRequestDto;
 
@@ -44,8 +45,10 @@ class CachingDelegate {
 
   private static final String CLIENT_STATE = "ClientState";
   private static final String CODE_VERIFIER = "CodeVerifier";
+  private static final String CREDENTIAL_DATA = "CredentialData";
   private static final String IDENTITY_DATA = "IdentityData";
   private static final String PUBLIC_KEY = "PublicKey";
+  private static final String TRAINEE_ID = "TraineeIdentifier";
   private static final String CREDENTIAL_LOG_DATA = "CredentialLogData";
   private static final String UNVERIFIED_SESSION_IDENTIFIER = "SessionIdentifier::Unverified";
   private static final String VERIFIED_SESSION_IDENTIFIER = "SessionIdentifier::Verified";
@@ -71,6 +74,30 @@ class CachingDelegate {
   @Cacheable(cacheNames = CODE_VERIFIER, cacheManager = VERIFICATION_REQUEST_DATA)
   @CacheEvict(CODE_VERIFIER)
   public Optional<String> getCodeVerifier(UUID key) {
+    return Optional.empty();
+  }
+
+  /**
+   * Cache an credential data dto for later retrieval.
+   *
+   * @param key The cache key.
+   * @param dto The credential data to cache.
+   * @return The cached credential data.
+   */
+  @CachePut(cacheNames = CREDENTIAL_DATA, cacheManager = CREDENTIAL_METADATA, key = "#key")
+  public CredentialDto cacheCredentialData(UUID key, CredentialDto dto) {
+    return dto;
+  }
+
+  /**
+   * Get the credential data associated with the given key, any cached value will be removed.
+   *
+   * @param key The cache key.
+   * @return The cached credential data, or an empty optional if not found.
+   */
+  @Cacheable(cacheNames = CREDENTIAL_DATA, cacheManager = CREDENTIAL_METADATA)
+  @CacheEvict(CREDENTIAL_DATA)
+  public Optional<CredentialDto> getCredentialData(UUID key) {
     return Optional.empty();
   }
 
@@ -142,6 +169,30 @@ class CachingDelegate {
    */
   @Cacheable(cacheNames = PUBLIC_KEY)
   public Optional<PublicKey> getPublicKey(String certificateThumbprint) {
+    return Optional.empty();
+  }
+
+  /**
+   * Cache a trainee identifier for later retrieval.
+   *
+   * @param key               The cache key.
+   * @param traineeIdentifier The trainee identifier to cache.
+   * @return The cached trainee identifier.
+   */
+  @CachePut(cacheNames = TRAINEE_ID, cacheManager = CREDENTIAL_METADATA, key = "#key")
+  public String cacheTraineeIdentifier(UUID key, String traineeIdentifier) {
+    return traineeIdentifier;
+  }
+
+  /**
+   * Get the trainee identifier associated with the given key, any cached value will be removed.
+   *
+   * @param key The cache key.
+   * @return The cached trainee identifier, or an empty optional if not found.
+   */
+  @Cacheable(cacheNames = TRAINEE_ID, cacheManager = CREDENTIAL_METADATA)
+  @CacheEvict(TRAINEE_ID)
+  public Optional<String> getTraineeIdentifier(UUID key) {
     return Optional.empty();
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegate.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegate.java
@@ -90,6 +90,18 @@ class CachingDelegate {
   }
 
   /**
+   * Cache a credential issuing request dto for later retrieval.
+   *
+   * @param key  The cache key.
+   * @param data The credential issue request metadata to cache.
+   * @return The cached credential log data.
+   */
+  @CachePut(cacheNames = CREDENTIAL_LOG_DATA, cacheManager = CREDENTIAL_METADATA, key = "#key")
+  public IssueRequestDto cacheCredentialData(UUID key, IssueRequestDto data) {
+    return data;
+  }
+
+  /**
    * Get the credential data associated with the given key, any cached value will be removed.
    *
    * @param key The cache key.
@@ -98,6 +110,19 @@ class CachingDelegate {
   @Cacheable(cacheNames = CREDENTIAL_DATA, cacheManager = CREDENTIAL_METADATA)
   @CacheEvict(CREDENTIAL_DATA)
   public Optional<CredentialDto> getCredentialData(UUID key) {
+    return Optional.empty();
+  }
+
+  /**
+   * Get the credential issue request metadata associated with the given key, any cached value will
+   * be removed.
+   *
+   * @param key The cache key.
+   * @return The cached credential issue request metadata, or an empty optional if not found.
+   */
+  @Cacheable(cacheNames = CREDENTIAL_LOG_DATA, cacheManager = CREDENTIAL_METADATA)
+  @CacheEvict(CREDENTIAL_LOG_DATA)
+  public Optional<IssueRequestDto> getCredentialMetadata(UUID key) {
     return Optional.empty();
   }
 
@@ -241,31 +266,6 @@ class CachingDelegate {
    */
   @Cacheable(cacheNames = VERIFIED_SESSION_IDENTIFIER, cacheManager = VERIFIED_SESSION_DATA)
   public Optional<String> getVerifiedSessionIdentifier(String sessionId) {
-    return Optional.empty();
-  }
-
-  /**
-   * Cache a credential issuing request dto for later retrieval.
-   *
-   * @param key  The cache key.
-   * @param data The credential issue request metadata to cache.
-   * @return The cached credential log data.
-   */
-  @CachePut(cacheNames = CREDENTIAL_LOG_DATA, cacheManager = CREDENTIAL_METADATA, key = "#key")
-  public IssueRequestDto cacheCredentialData(UUID key, IssueRequestDto data) {
-    return data;
-  }
-
-  /**
-   * Get the credential issue request metadata associated with the given key, any cached value will
-   * be removed.
-   *
-   * @param key The cache key.
-   * @return The cached credential issue request metadata, or an empty optional if not found.
-   */
-  @Cacheable(cacheNames = CREDENTIAL_LOG_DATA, cacheManager = CREDENTIAL_METADATA)
-  @CacheEvict(CREDENTIAL_LOG_DATA)
-  public Optional<IssueRequestDto> getCredentialMetadata(UUID key) {
     return Optional.empty();
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayService.java
@@ -75,11 +75,12 @@ public class GatewayService {
    * Get a URI to be used to issue a credential for the given credential data.
    *
    * @param dto   The credential data to be issued.
-   * @param state The client state.
+   * @param nonce The nonce.
+   * @param state The state.
    * @return The URI to issue the credential.
    */
-  public Optional<URI> getCredentialUri(CredentialDto dto, String state) {
-    HttpEntity<MultiValueMap<String, String>> request = buildParRequest(dto, state);
+  public Optional<URI> getCredentialUri(CredentialDto dto, String nonce, String state) {
+    HttpEntity<MultiValueMap<String, String>> request = buildParRequest(dto, nonce, state);
 
     log.info("Sending PAR request.");
     ResponseEntity<ParResponse> response = restTemplate.postForEntity(
@@ -93,15 +94,14 @@ public class GatewayService {
    * Build a request to send to the PAR endpoint.
    *
    * @param dto   The dto to build a credential for.
-   * @param state The client state.
+   * @param state The state.
    * @return The built request.
    */
-  private HttpEntity<MultiValueMap<String, String>> buildParRequest(CredentialDto dto,
+  private HttpEntity<MultiValueMap<String, String>> buildParRequest(CredentialDto dto, String nonce,
       String state) {
     log.info("Building PAR request.");
     String idTokenHint = jwtService.generateToken(dto);
 
-    String nonce = UUID.randomUUID().toString();
     MultiValueMap<String, String> bodyPair = new LinkedMultiValueMap<>();
     bodyPair.add("client_id", properties.clientId());
     bodyPair.add("client_secret", properties.clientSecret());

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/IssuanceService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/IssuanceService.java
@@ -1,0 +1,81 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.service;
+
+import io.jsonwebtoken.Claims;
+import java.net.URI;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDto;
+
+/**
+ * A service providing credential issuance functionality.
+ */
+@Service
+public class IssuanceService {
+
+  private final GatewayService gatewayService;
+  private final JwtService jwtService;
+  private final CachingDelegate cachingDelegate;
+
+  /**
+   * Create a service providing credential issuance functionality.
+   *
+   * @param gatewayService  The service to handle all credential gateway interactions.
+   * @param jwtService      The JWT service to use.
+   * @param cachingDelegate The caching delegate for caching data between requests.
+   */
+  IssuanceService(GatewayService gatewayService, JwtService jwtService,
+      CachingDelegate cachingDelegate) {
+    this.gatewayService = gatewayService;
+    this.jwtService = jwtService;
+    this.cachingDelegate = cachingDelegate;
+  }
+
+  /**
+   * Start the issuance of a credential.
+   *
+   * @param authToken   The request's authorization token.
+   * @param dto         The user's identity data.
+   * @param clientState The state sent by client when making the request to start verification.
+   * @return The URI to continue the issuing via credential gateway, or empty if issuing failed.
+   */
+  public Optional<URI> startCredentialIssuance(String authToken, CredentialDto dto,
+      @Nullable String clientState) {
+    // Cache the provided identity data against the nonce.
+    UUID nonce = UUID.randomUUID();
+    cachingDelegate.cacheCredentialData(nonce, dto);
+
+    // Generate new state for the internal request/callback and cache the client state.
+    UUID internalState = UUID.randomUUID();
+    cachingDelegate.cacheClientState(internalState, clientState);
+
+    // Cache an ID from the token to represent the session.
+    Claims authClaims = jwtService.getClaims(authToken);
+    String traineeId = authClaims.get("custom:tisId", String.class);
+    cachingDelegate.cacheTraineeIdentifier(internalState, traineeId);
+
+    return gatewayService.getCredentialUri(dto, nonce.toString(), internalState.toString());
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/TestCredentialDto.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/TestCredentialDto.java
@@ -19,38 +19,28 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.trainee.credentials.dto;
+package uk.nhs.hee.tis.trainee.credentials;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import java.io.Serializable;
 import java.time.Instant;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDto;
 
 /**
- * An interface representing a DTO containing credential data.
+ * An implementation of {@link CredentialDto} for test purposes.
  */
-public interface CredentialDto extends Serializable {
+public record TestCredentialDto(String tisId) implements CredentialDto {
 
-  /**
-   * Get the TIS ID of the record, which is recorded in the credential metadata, not the credential
-   * itself.
-   */
-  @JsonIgnore
-  String getTisId();
+  @Override
+  public String getTisId() {
+    return tisId();
+  }
 
-  /**
-   * Get the expiry instant for the credential.
-   *
-   * @param issuedAt The time the credential is being issued.
-   * @return The expiry instant of the credential.
-   */
-  @JsonIgnore
-  Instant getExpiration(Instant issuedAt);
+  @Override
+  public Instant getExpiration(Instant issuedAt) {
+    return Instant.MAX;
+  }
 
-  /**
-   * Get gateway credential type, known as scope internally.
-   *
-   * @return The credential's scope.
-   */
-  @JsonIgnore
-  String getScope();
+  @Override
+  public String getScope() {
+    return "test.Credential";
+  }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegateIntegrationTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegateIntegrationTest.java
@@ -35,6 +35,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.hee.tis.trainee.credentials.TestCredentialDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDto;
 import uk.nhs.hee.tis.trainee.credentials.dto.IdentityDataDto;
 import uk.nhs.hee.tis.trainee.credentials.dto.IssueRequestDto;
 
@@ -131,6 +133,48 @@ class CachingDelegateIntegrationTest {
   }
 
   @Test
+  void shouldReturnEmptyCredentialDataWhenNotCached() {
+    UUID key = UUID.randomUUID();
+
+    Optional<CredentialDto> cachedOptional = delegate.getCredentialData(key);
+    assertThat("Unexpected cached value.", cachedOptional, is(Optional.empty()));
+  }
+
+  @Test
+  void shouldReturnCachedCredentialDataAfterCaching() {
+    UUID key = UUID.randomUUID();
+
+    CredentialDto credentialData = new TestCredentialDto("123");
+    CredentialDto cachedData = delegate.cacheCredentialData(key, credentialData);
+    assertThat("Unexpected cached value.", cachedData, is(credentialData));
+  }
+
+  @Test
+  void shouldGetCachedCredentialDataWhenCached() {
+    UUID key = UUID.randomUUID();
+
+    CredentialDto credentialData = new TestCredentialDto("123");
+    delegate.cacheCredentialData(key, credentialData);
+
+    Optional<CredentialDto> cachedOptional = delegate.getCredentialData(key);
+    assertThat("Unexpected cached value.", cachedOptional, is(Optional.of(credentialData)));
+  }
+
+  @Test
+  void shouldRemoveCredentialDataWhenRetrieved() {
+    UUID key = UUID.randomUUID();
+
+    CredentialDto credentialData = new TestCredentialDto("123");
+    delegate.cacheCredentialData(key, credentialData);
+
+    // Ignore this result, the cached value should be evicted.
+    delegate.getCredentialData(key);
+
+    Optional<CredentialDto> cachedOptional = delegate.getCredentialData(key);
+    assertThat("Unexpected cached value.", cachedOptional, is(Optional.empty()));
+  }
+
+  @Test
   void shouldReturnEmptyIdentityDataWhenNotCached() {
     UUID key = UUID.randomUUID();
 
@@ -208,6 +252,48 @@ class CachingDelegateIntegrationTest {
 
     Optional<PublicKey> cachedOptional = delegate.getPublicKey(certificateThumbprint);
     assertThat("Unexpected cached value.", cachedOptional, is(Optional.of(publicKey)));
+  }
+
+  @Test
+  void shouldReturnEmptyTraineeIdentifierWhenNotCached() {
+    UUID key = UUID.randomUUID();
+
+    Optional<String> cachedOptional = delegate.getTraineeIdentifier(key);
+    assertThat("Unexpected cached value.", cachedOptional, is(Optional.empty()));
+  }
+
+  @Test
+  void shouldReturnCachedTraineeIdentifierAfterCaching() {
+    UUID key = UUID.randomUUID();
+
+    String traineeIdentifier = "123";
+    String cachedData = delegate.cacheTraineeIdentifier(key, traineeIdentifier);
+    assertThat("Unexpected cached value.", cachedData, is(traineeIdentifier));
+  }
+
+  @Test
+  void shouldGetCachedTraineeIdentifierWhenCached() {
+    UUID key = UUID.randomUUID();
+
+    String traineeIdentifier = "123";
+    delegate.cacheTraineeIdentifier(key, traineeIdentifier);
+
+    Optional<String> cachedOptional = delegate.getTraineeIdentifier(key);
+    assertThat("Unexpected cached value.", cachedOptional, is(Optional.of(traineeIdentifier)));
+  }
+
+  @Test
+  void shouldRemoveTraineeIdentifierWhenRetrieved() {
+    UUID key = UUID.randomUUID();
+
+    String traineeIdentifier = "123";
+    delegate.cacheTraineeIdentifier(key, traineeIdentifier);
+
+    // Ignore this result, the cached value should be evicted.
+    delegate.getTraineeIdentifier(key);
+
+    Optional<String> cachedOptional = delegate.getTraineeIdentifier(key);
+    assertThat("Unexpected cached value.", cachedOptional, is(Optional.empty()));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegateTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegateTest.java
@@ -32,6 +32,8 @@ import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.nhs.hee.tis.trainee.credentials.TestCredentialDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDto;
 import uk.nhs.hee.tis.trainee.credentials.dto.IdentityDataDto;
 import uk.nhs.hee.tis.trainee.credentials.dto.IssueRequestDto;
 
@@ -69,6 +71,20 @@ class CachingDelegateTest {
   }
 
   @Test
+  void shouldReturnCachedCredentialData() {
+    CredentialDto credentialData = new TestCredentialDto("123");
+    CredentialDto cachedCredentialData = delegate.cacheCredentialData(UUID.randomUUID(),
+        credentialData);
+    assertThat("Unexpected credential data.", cachedCredentialData, is(credentialData));
+  }
+
+  @Test
+  void shouldGetEmptyCredentialData() {
+    Optional<CredentialDto> credentialData = delegate.getCredentialData(UUID.randomUUID());
+    assertThat("Unexpected credential data.", credentialData, is(Optional.empty()));
+  }
+
+  @Test
   void shouldReturnCachedIdentityData() {
     IdentityDataDto identityData = new IdentityDataDto("Anthony", "Gilliam", LocalDate.now());
     IdentityDataDto returnValue = delegate.cacheIdentityData(UUID.randomUUID(), identityData);
@@ -92,6 +108,18 @@ class CachingDelegateTest {
   void shouldGetEmptyIdentityData() {
     Optional<IdentityDataDto> identityData = delegate.getIdentityData(UUID.randomUUID());
     assertThat("Unexpected identity data.", identityData, is(Optional.empty()));
+  }
+
+  @Test
+  void shouldReturnCachedTraineeIdentifier() {
+    String traineeIdentifier = delegate.cacheTraineeIdentifier(UUID.randomUUID(), "123");
+    assertThat("Unexpected trainee identifier.", traineeIdentifier, is("123"));
+  }
+
+  @Test
+  void shouldGetEmptyTraineeIdentifier() {
+    Optional<String> traineeIdentifier = delegate.getTraineeIdentifier(UUID.randomUUID());
+    assertThat("Unexpected trainee identifier.", traineeIdentifier, is(Optional.empty()));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayServiceTest.java
@@ -22,7 +22,6 @@
 package uk.nhs.hee.tis.trainee.credentials.service;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
@@ -69,6 +68,7 @@ class GatewayServiceTest {
   private static final String REDIRECT_URI = "https://redirect.uri";
   private static final String CALLBACK_URI = "https://callback.uri";
 
+  private static final String NONCE = UUID.randomUUID().toString();
   private static final String STATE = "some-client-state";
 
   private GatewayService service;
@@ -116,7 +116,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
         eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
 
-    service.getCredentialUri(dto, STATE);
+    service.getCredentialUri(dto, NONCE, STATE);
 
     HttpHeaders headers = argumentCaptor.getValue().getHeaders();
     assertThat("Unexpected accept header.", headers.get(HttpHeaders.ACCEPT),
@@ -133,7 +133,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
         eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
 
-    service.getCredentialUri(dto, STATE);
+    service.getCredentialUri(dto, NONCE, STATE);
 
     HttpHeaders headers = argumentCaptor.getValue().getHeaders();
     assertThat("Unexpected content type header.", headers.get(HttpHeaders.CONTENT_TYPE),
@@ -148,7 +148,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
         eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
 
-    service.getCredentialUri(dto, STATE);
+    service.getCredentialUri(dto, NONCE, STATE);
 
     var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
     MultiValueMap<String, String> requestBody = request.getBody();
@@ -163,7 +163,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
         eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
 
-    service.getCredentialUri(dto, STATE);
+    service.getCredentialUri(dto, NONCE, STATE);
 
     var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
     MultiValueMap<String, String> requestBody = request.getBody();
@@ -180,7 +180,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
         eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
 
-    service.getCredentialUri(dto, STATE);
+    service.getCredentialUri(dto, NONCE, STATE);
 
     var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
     MultiValueMap<String, String> requestBody = request.getBody();
@@ -196,7 +196,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
         eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
 
-    service.getCredentialUri(dto, STATE);
+    service.getCredentialUri(dto, NONCE, STATE);
 
     var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
     MultiValueMap<String, String> requestBody = request.getBody();
@@ -212,7 +212,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
         eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
 
-    service.getCredentialUri(dto, STATE);
+    service.getCredentialUri(dto, NONCE, STATE);
 
     var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
     MultiValueMap<String, String> requestBody = request.getBody();
@@ -229,7 +229,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
         eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
 
-    service.getCredentialUri(dto, STATE);
+    service.getCredentialUri(dto, NONCE, STATE);
 
     var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
     MultiValueMap<String, String> requestBody = request.getBody();
@@ -245,7 +245,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
         eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
 
-    service.getCredentialUri(dto, STATE);
+    service.getCredentialUri(dto, NONCE, STATE);
 
     var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
     MultiValueMap<String, String> requestBody = request.getBody();
@@ -260,11 +260,11 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
         eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
 
-    service.getCredentialUri(dto, STATE);
+    service.getCredentialUri(dto, NONCE, STATE);
 
     var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
     MultiValueMap<String, String> requestBody = request.getBody();
-    assertThat("Unexpected nonce.", requestBody.get("nonce"), notNullValue());
+    assertThat("Unexpected nonce.", requestBody.get("nonce"), is(List.of(NONCE)));
   }
 
   @Test
@@ -277,7 +277,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
         eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
 
-    service.getCredentialUri(dto, STATE);
+    service.getCredentialUri(dto, NONCE, STATE);
 
     var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
     MultiValueMap<String, String> requestBody = request.getBody();
@@ -292,7 +292,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), any(), eq(ParResponse.class))).thenReturn(
         ResponseEntity.notFound().build());
 
-    Optional<URI> optional = service.getCredentialUri(dto, STATE);
+    Optional<URI> optional = service.getCredentialUri(dto, NONCE, STATE);
 
     assertThat("Unexpected URI presence.", optional.isPresent(), is(false));
   }
@@ -305,7 +305,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), any(), eq(ParResponse.class))).thenReturn(
         response);
 
-    Optional<URI> optional = service.getCredentialUri(dto, STATE);
+    Optional<URI> optional = service.getCredentialUri(dto, NONCE, STATE);
 
     assertThat("Unexpected URI presence.", optional.isPresent(), is(false));
   }
@@ -319,7 +319,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(PAR_ENDPOINT), any(), eq(ParResponse.class))).thenReturn(
         response);
 
-    Optional<URI> optional = service.getCredentialUri(dto, STATE);
+    Optional<URI> optional = service.getCredentialUri(dto, NONCE, STATE);
 
     assertThat("Unexpected URI presence.", optional.isPresent(), is(true));
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/IssuanceServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/IssuanceServiceTest.java
@@ -1,0 +1,140 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.jsonwebtoken.impl.DefaultClaims;
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import uk.nhs.hee.tis.trainee.credentials.TestCredentialDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDto;
+
+class IssuanceServiceTest {
+
+  private static final String AUTH_TOKEN = "dummy-auth-token";
+
+  private IssuanceService issuanceService;
+  private GatewayService gatewayService;
+  private JwtService jwtService;
+  private CachingDelegate cachingDelegate;
+
+  @BeforeEach
+  void setUp() {
+    gatewayService = mock(GatewayService.class);
+    jwtService = mock(JwtService.class);
+    cachingDelegate = mock(CachingDelegate.class);
+    issuanceService = new IssuanceService(gatewayService, jwtService, cachingDelegate);
+  }
+
+  @Test
+  void shouldCacheCredentialDataAgainstNonceWhenStartingIssuance() {
+    CredentialDto credentialData = new TestCredentialDto("123");
+    when(jwtService.getClaims(any())).thenReturn(new DefaultClaims());
+
+    issuanceService.startCredentialIssuance(null, credentialData, null);
+
+    ArgumentCaptor<UUID> cacheKeyCaptor = ArgumentCaptor.forClass(UUID.class);
+    verify(cachingDelegate).cacheCredentialData(cacheKeyCaptor.capture(), eq(credentialData));
+
+    ArgumentCaptor<String> requestNonceCaptor = ArgumentCaptor.forClass(String.class);
+    verify(gatewayService).getCredentialUri(any(), requestNonceCaptor.capture(), any());
+
+    UUID cacheKey = cacheKeyCaptor.getValue();
+    String requestNonce = requestNonceCaptor.getValue();
+    assertThat("Unexpected nonce cache key.", cacheKey.toString(), is(requestNonce));
+  }
+
+  @Test
+  void shouldCacheClientStateAgainstInternalStateWhenStartingIssuance() {
+    when(jwtService.getClaims(any())).thenReturn(new DefaultClaims());
+
+    issuanceService.startCredentialIssuance(null, null, "some-client-state");
+
+    ArgumentCaptor<UUID> cacheKeyCaptor = ArgumentCaptor.forClass(UUID.class);
+    verify(cachingDelegate).cacheClientState(cacheKeyCaptor.capture(), eq("some-client-state"));
+
+    ArgumentCaptor<String> requestStateCaptor = ArgumentCaptor.forClass(String.class);
+    verify(gatewayService).getCredentialUri(any(), any(), requestStateCaptor.capture());
+
+    UUID cacheKey = cacheKeyCaptor.getValue();
+    String requestState = requestStateCaptor.getValue();
+    assertThat("Unexpected state cache key.", cacheKey.toString(), is(requestState));
+  }
+
+  @Test
+  void shouldCacheTraineeIdentifierAgainstInternalStateWhenStartingIssuance() {
+    when(jwtService.getClaims(AUTH_TOKEN)).thenReturn(new DefaultClaims(Map.of(
+        "custom:tisId", "123"
+    )));
+
+    issuanceService.startCredentialIssuance(AUTH_TOKEN, null, null);
+
+    ArgumentCaptor<UUID> cacheKeyCaptor = ArgumentCaptor.forClass(UUID.class);
+    verify(cachingDelegate).cacheTraineeIdentifier(cacheKeyCaptor.capture(), eq("123"));
+
+    ArgumentCaptor<String> requestStateCaptor = ArgumentCaptor.forClass(String.class);
+    verify(gatewayService).getCredentialUri(any(), any(), requestStateCaptor.capture());
+
+    UUID cacheKey = cacheKeyCaptor.getValue();
+    String requestState = requestStateCaptor.getValue();
+    assertThat("Unexpected state cache key.", cacheKey.toString(), is(requestState));
+  }
+
+  @Test
+  void shouldReturnEmptyWhenGatewayRequestFails() {
+    when(jwtService.getClaims(AUTH_TOKEN)).thenReturn(new DefaultClaims());
+    CredentialDto credentialData = new TestCredentialDto("123");
+
+    when(gatewayService.getCredentialUri(eq(credentialData), any(), any())).thenReturn(
+        Optional.empty());
+
+    Optional<URI> uri = issuanceService.startCredentialIssuance(AUTH_TOKEN, credentialData, null);
+
+    assertThat("Unexpected URI.", uri, is(Optional.empty()));
+  }
+
+  @Test
+  void shouldReturnRedirectUriWhenGatewayRequestSuccessful() {
+    when(jwtService.getClaims(AUTH_TOKEN)).thenReturn(new DefaultClaims());
+    CredentialDto credentialData = new TestCredentialDto("123");
+
+    URI redirectUri = URI.create("/redirect-uri");
+    when(gatewayService.getCredentialUri(eq(credentialData), any(), any())).thenReturn(
+        Optional.of(redirectUri));
+
+    Optional<URI> uri = issuanceService.startCredentialIssuance(AUTH_TOKEN, credentialData, null);
+
+    assertThat("Unexpected URI.", uri, is(Optional.of(redirectUri)));
+  }
+}


### PR DESCRIPTION
Refactoring/increment of the initial issue request side to ensure that additional data is properly cached for later retrieval, specifically
 - Trainee ID
 - Incoming Placement/ProgrammeMembership data
 - The original request's `state` param

The caching previously added to `GatewayService` has not yet been removed, that will be done as part of refactoring the callback handling in to the `IssuanceService`.