### PR TITLE
fix: DB connection param configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,22 @@ gradlew bootRun
 
 #### Environmental Variables
 
-| Name                              | Description                                                                                                             | Default |
-|-----------------------------------|-------------------------------------------------------------------------------------------------------------------------|---------|
-| GATEWAY_HOST                      | The credential gateway host.                                                                                            |         |
-| GATEWAY_CLIENT_ID                 | The client ID for the credential gateway.                                                                               |         |
-| GATEWAY_CLIENT_SECRET             | The client secret for the credential gateway.                                                                           |         |
-| GATEWAY_TOKEN_SIGNING_KEY         | The Base64 encoded signing key for the credential data.                                                                 |         |
-| GATEWAY_ISSUING_REDIRECT_URI      | Where the gateway issue should redirect to after issuing.                                                               |         |
-| GATEWAY_VERIFICATION_REDIRECT_URI | Where the gateway issue should redirect to verify a supplied credential, e.g. `<host>/api/credentials/verify/callback`. |         |
-| SENTRY_DSN                        | A Sentry error monitoring Data Source Name.                                                                             |         |
-| SENTRY_ENVIRONMENT                | The environment to log Sentry events against.                                                                           | local   |
-| SIGNATURE_SECRET_KEY              | The secret key used to validate signed data.                                                                            |         |
+| Name                              | Description                                                                                                             | Default     |
+|-----------------------------------|-------------------------------------------------------------------------------------------------------------------------|-------------|
+| DB_HOST                           | The MongoDB host to connect to.                                                                                         | localhost   |
+| DB_PORT                           | The port to connect to MongoDB on.                                                                                      | 27017       |
+| DB_NAME                           | The name of the MongoDB database.                                                                                       | credentials |
+| DB_USER                           | The username to access the MongoDB instance.                                                                            | admin       |
+| DB_PASSWORD                       | The password to access the MongoDB instance.                                                                            | pwd         |
+| GATEWAY_HOST                      | The credential gateway host.                                                                                            |             |
+| GATEWAY_CLIENT_ID                 | The client ID for the credential gateway.                                                                               |             |
+| GATEWAY_CLIENT_SECRET             | The client secret for the credential gateway.                                                                           |             |
+| GATEWAY_TOKEN_SIGNING_KEY         | The Base64 encoded signing key for the credential data.                                                                 |             |
+| GATEWAY_ISSUING_REDIRECT_URI      | Where the gateway issue should redirect to after issuing.                                                               |             |
+| GATEWAY_VERIFICATION_REDIRECT_URI | Where the gateway issue should redirect to verify a supplied credential, e.g. `<host>/api/credentials/verify/callback`. |             |
+| SENTRY_DSN                        | A Sentry error monitoring Data Source Name.                                                                             |             |
+| SENTRY_ENVIRONMENT                | The environment to log Sentry events against.                                                                           | local       |
+| SIGNATURE_SECRET_KEY              | The secret key used to validate signed data.                                                                            |             |
 
 #### Usage Examples
 


### PR DESCRIPTION
The DB  connection is currently not configured, so logging credentials fails:


```
2023-03-01T09:14:21.440Z  INFO 1 --- [nio-8210-exec-4] u.n.h.t.t.c.service.IssuanceService      : Credential was issued successfully.
--
2023-03-01T09:14:21.440Z  INFO 1 --- [nio-8210-exec-4] u.n.h.t.t.c.service.GatewayService       : Building Token request.
2023-03-01T09:14:21.440Z  INFO 1 --- [nio-8210-exec-4] u.n.h.t.t.c.service.GatewayService       : Built Token request.
2023-03-01T09:14:21.440Z  INFO 1 --- [nio-8210-exec-4] u.n.h.t.t.c.service.GatewayService       : Sending token request.
2023-03-01T09:14:21.819Z  INFO 1 --- [nio-8210-exec-4] u.n.h.t.t.c.service.GatewayService       : Received token response.
2023-03-01T09:14:22.354Z  INFO 1 --- [nio-8210-exec-4] org.mongodb.driver.cluster               : Cluster description not yet available. Waiting for 30000 ms before timing out
2023-03-01T09:14:52.362Z ERROR 1 --- [nio-8210-exec-4] o.a.c.c.C.[.[.[.[dispatcherServlet]      : Servlet.service() for servlet [dispatcherServlet] in context with path [/credentials] threw exception [Request processing failed: org.springframework.dao.DataAccessResourceFailureException: Timed out after 30000 ms while waiting to connect. Client view of cluster state is {type=UNKNOWN, servers=[{address=localhost:27017, type=UNKNOWN, state=CONNECTING, exception={com.mongodb.MongoSocketOpenException: Exception opening socket}, caused by {java.net.ConnectException: Connection refused}}]] with root cause
com.mongodb.MongoTimeoutException: Timed out after 30000 ms while waiting to connect. Client view of cluster state is {type=UNKNOWN, servers=[{address=localhost:27017, type=UNKNOWN, state=CONNECTING, exception={com.mongodb.MongoSocketOpenException: Exception opening socket}, caused by {java.net.ConnectException: Connection refused}}]
at com.mongodb.internal.connection.BaseCluster.getDescription(BaseCluster.java:184)

```

TIS21-4110