### PR TITLE
feat: invalidate signatures when data modified

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/CredentialType.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/CredentialType.java
@@ -21,46 +21,42 @@
 
 package uk.nhs.hee.tis.trainee.credentials.dto;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.Optional;
+import lombok.Getter;
 
 /**
- * A DTO representing a Programme Membership credential.
- *
- * @param programmeName The programme name.
- * @param startDate     The programme's start date.
- * @param endDate       The programme's end date.
+ * An enumeration of available credential types.
  */
-public record ProgrammeMembershipCredentialDto(
-    @JsonIgnore
-    String tisId,
+@Getter
+public enum CredentialType {
 
-    @JsonProperty("TPR-Name")
-    String programmeName,
+  TRAINING_PLACEMENT("issue.TrainingPlacement", "/api/issue/placement"),
+  TRAINING_PROGRAMME("issue.TrainingProgramme", "/api/issue/programme-membership");
 
-    @JsonProperty("TPR-ProgrammeStartDate")
-    LocalDate startDate,
+  private final String gatewayScope;
+  private final String apiPath;
 
-    @JsonProperty("TPR-ProgrammeEndDate")
-    LocalDate endDate
-) implements CredentialDto {
-
-  @Override
-  public Instant getExpiration(Instant issuedAt) {
-    return endDate.atTime(LocalTime.MAX).toInstant(ZoneOffset.UTC);
+  /**
+   * Construct a credential type.
+   *
+   * @param gatewayScope The gateway scope e.g. issue.DataType.
+   * @param apiPath      The API request path for the credential type.
+   */
+  CredentialType(String gatewayScope, String apiPath) {
+    this.gatewayScope = gatewayScope;
+    this.apiPath = apiPath;
   }
 
-  @Override
-  public String getScope() {
-    return CredentialType.TRAINING_PROGRAMME.getGatewayScope();
-  }
-
-  @Override
-  public String getTisId() {
-    return tisId;
+  /**
+   * Get the credential type matching the given path.
+   *
+   * @param apiPath The API path to match.
+   * @return The matched credential type, or else empty.
+   */
+  public static Optional<CredentialType> fromPath(String apiPath) {
+    return Arrays.stream(CredentialType.values())
+        .filter(ct -> ct.apiPath.equals(apiPath))
+        .findFirst();
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/PlacementCredentialDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/PlacementCredentialDto.java
@@ -72,7 +72,7 @@ public record PlacementCredentialDto(
 
   @Override
   public String getScope() {
-    return "issue.TrainingPlacement";
+    return CredentialType.TRAINING_PLACEMENT.getGatewayScope();
   }
 
   @Override

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/filter/SignedDataFilter.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/filter/SignedDataFilter.java
@@ -61,6 +61,7 @@ public class SignedDataFilter extends OncePerRequestFilter {
    *
    * @param mapper             An {@link ObjectMapper} to use when reading the request payload.
    * @param signatureSecretKey The secret key used to sign and verify the signature.
+   * @param revocationService  The revocation service instance to use.
    */
   SignedDataFilter(ObjectMapper mapper,
       @Value("${application.signature.secret-key}") String signatureSecretKey,

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/filter/SignedDataFilter.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/filter/SignedDataFilter.java
@@ -47,8 +47,6 @@ import uk.nhs.hee.tis.trainee.credentials.service.RevocationService;
 @Component
 public class SignedDataFilter extends OncePerRequestFilter {
 
-  private static final String ISSUE_PATH = "/api/issue/";
-
   private static final String SIGNATURE_FIELD = "signature";
   private static final String HMAC_FIELD = "hmac";
   private static final String TIS_ID_FIELD = "tisId";
@@ -136,15 +134,14 @@ public class SignedDataFilter extends OncePerRequestFilter {
    */
   private boolean isDataValid(HttpServletRequest request, JsonNode tree, Signature signature) {
     String servletPath = request.getServletPath();
+    Optional<CredentialType> credentialType = CredentialType.fromPath(servletPath);
 
-    // Skip data validation unless issuing a credential.
-    if (!servletPath.startsWith(ISSUE_PATH)) {
+    // Skip validation for any request without a matching credential type.
+    if (credentialType.isEmpty()) {
       return true;
     }
 
-    Optional<CredentialType> credentialType = CredentialType.fromPath(servletPath);
-
-    if (credentialType.isEmpty() || !tree.has(TIS_ID_FIELD)) {
+    if (!tree.has(TIS_ID_FIELD)) {
       return false;
     }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/model/CredentialMetadata.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/model/CredentialMetadata.java
@@ -31,7 +31,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.stereotype.Component;
 
 /**
- * A credential metadata record with all properties needed to store permenently.
+ * A credential metadata record with all properties needed to store permanently.
  */
 @Component(CredentialMetadata.ENTITY_NAME)
 @Scope(SCOPE_PROTOTYPE)

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/model/ModificationMetadata.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/model/ModificationMetadata.java
@@ -19,48 +19,36 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.trainee.credentials.dto;
+package uk.nhs.hee.tis.trainee.credentials.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.ZoneOffset;
+import org.springframework.data.annotation.Id;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialType;
 
 /**
- * A DTO representing a Programme Membership credential.
- *
- * @param programmeName The programme name.
- * @param startDate     The programme's start date.
- * @param endDate       The programme's end date.
+ * Metadata of modified data related to credentials.
  */
-public record ProgrammeMembershipCredentialDto(
-    @JsonIgnore
-    String tisId,
+public record ModificationMetadata(@Id ModificationMetadataId id, Instant lastModifiedDate) {
 
-    @JsonProperty("TPR-Name")
-    String programmeName,
-
-    @JsonProperty("TPR-ProgrammeStartDate")
-    LocalDate startDate,
-
-    @JsonProperty("TPR-ProgrammeEndDate")
-    LocalDate endDate
-) implements CredentialDto {
-
-  @Override
-  public Instant getExpiration(Instant issuedAt) {
-    return endDate.atTime(LocalTime.MAX).toInstant(ZoneOffset.UTC);
+  /**
+   * Create a metadata object for data modification.
+   *
+   * @param tisId            The TIS ID of the modified data.
+   * @param credentialType   The credential type related to the data object.
+   * @param lastModifiedDate The instant of the modification.
+   */
+  public ModificationMetadata(String tisId, CredentialType credentialType,
+      Instant lastModifiedDate) {
+    this(new ModificationMetadataId(tisId, credentialType), lastModifiedDate);
   }
 
-  @Override
-  public String getScope() {
-    return CredentialType.TRAINING_PROGRAMME.getGatewayScope();
-  }
+  /**
+   * A composite ID containing both the TIS ID and credential type.
+   *
+   * @param tisId          The TIS ID of the modified data..
+   * @param credentialType The credential type related to the data object.
+   */
+  public record ModificationMetadataId(String tisId, CredentialType credentialType) {
 
-  @Override
-  public String getTisId() {
-    return tisId;
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/repository/ModificationMetadataRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/repository/ModificationMetadataRepository.java
@@ -19,48 +19,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.trainee.credentials.dto;
+package uk.nhs.hee.tis.trainee.credentials.repository;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.ZoneOffset;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import uk.nhs.hee.tis.trainee.credentials.model.ModificationMetadata;
+import uk.nhs.hee.tis.trainee.credentials.model.ModificationMetadata.ModificationMetadataId;
 
 /**
- * A DTO representing a Programme Membership credential.
- *
- * @param programmeName The programme name.
- * @param startDate     The programme's start date.
- * @param endDate       The programme's end date.
+ * A repository for data modification metadata records.
  */
-public record ProgrammeMembershipCredentialDto(
-    @JsonIgnore
-    String tisId,
+public interface ModificationMetadataRepository extends
+    MongoRepository<ModificationMetadata, ModificationMetadataId> {
 
-    @JsonProperty("TPR-Name")
-    String programmeName,
-
-    @JsonProperty("TPR-ProgrammeStartDate")
-    LocalDate startDate,
-
-    @JsonProperty("TPR-ProgrammeEndDate")
-    LocalDate endDate
-) implements CredentialDto {
-
-  @Override
-  public Instant getExpiration(Instant issuedAt) {
-    return endDate.atTime(LocalTime.MAX).toInstant(ZoneOffset.UTC);
-  }
-
-  @Override
-  public String getScope() {
-    return CredentialType.TRAINING_PROGRAMME.getGatewayScope();
-  }
-
-  @Override
-  public String getTisId() {
-    return tisId;
-  }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationService.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.service;
+
+import java.time.Instant;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialType;
+import uk.nhs.hee.tis.trainee.credentials.model.ModificationMetadata;
+import uk.nhs.hee.tis.trainee.credentials.model.ModificationMetadata.ModificationMetadataId;
+import uk.nhs.hee.tis.trainee.credentials.repository.ModificationMetadataRepository;
+
+/**
+ * A service providing credential revocation functionality.
+ */
+@Service
+public class RevocationService {
+
+  private final ModificationMetadataRepository modificationMetadataRepository;
+
+  RevocationService(ModificationMetadataRepository modificationMetadataRepository) {
+    this.modificationMetadataRepository = modificationMetadataRepository;
+  }
+
+  /**
+   * Get the last modified date for the record with matching credential type and ID.
+   *
+   * @param tisId          The TIS ID of the modified object.
+   * @param credentialType The credential type of the modified object.
+   * @return The {@link Instant} of the last modification, or empty if never modified.
+   */
+  public Optional<Instant> getLastModifiedDate(String tisId, CredentialType credentialType) {
+    ModificationMetadataId id = new ModificationMetadataId(tisId, credentialType);
+    Optional<ModificationMetadata> metadata = modificationMetadataRepository.findById(id);
+
+    return metadata.map(ModificationMetadata::lastModifiedDate);
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/api/IssueResourceTest.java
@@ -63,6 +63,7 @@ import uk.nhs.hee.tis.trainee.credentials.dto.ProgrammeMembershipCredentialDto;
 import uk.nhs.hee.tis.trainee.credentials.filter.FilterConfiguration;
 import uk.nhs.hee.tis.trainee.credentials.mapper.CredentialDataMapper;
 import uk.nhs.hee.tis.trainee.credentials.service.IssuanceService;
+import uk.nhs.hee.tis.trainee.credentials.service.RevocationService;
 import uk.nhs.hee.tis.trainee.credentials.service.VerificationService;
 
 @WebMvcTest(IssueResource.class)
@@ -129,6 +130,9 @@ class IssueResourceTest {
 
   @MockBean
   private IssuanceService issuanceService;
+
+  @MockBean
+  private RevocationService revocationService;
 
   @MockBean
   private VerificationService verificationService;

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/api/VerifyResourceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/api/VerifyResourceTest.java
@@ -55,6 +55,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import uk.nhs.hee.tis.trainee.credentials.SignatureTestUtil;
 import uk.nhs.hee.tis.trainee.credentials.dto.IdentityDataDto;
 import uk.nhs.hee.tis.trainee.credentials.filter.FilterConfiguration;
+import uk.nhs.hee.tis.trainee.credentials.service.RevocationService;
 import uk.nhs.hee.tis.trainee.credentials.service.VerificationService;
 
 @WebMvcTest(VerifyResource.class)
@@ -83,6 +84,9 @@ class VerifyResourceTest {
 
   @Autowired
   private MockMvc mockMvc;
+
+  @MockBean
+  private RevocationService revocationService;
 
   @MockBean
   private VerificationService service;

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/filter/FilterConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/filter/FilterConfigurationTest.java
@@ -46,7 +46,7 @@ class FilterConfigurationTest {
 
   @Test
   void shouldRegisterSignedDataFilter() {
-    SignedDataFilter filter = new SignedDataFilter(new ObjectMapper(), SIGNATURE_SECRET_KEY);
+    SignedDataFilter filter = new SignedDataFilter(new ObjectMapper(), SIGNATURE_SECRET_KEY, null);
 
     var registrationBean = configuration.registerSignedDataFilter(filter);
 
@@ -56,7 +56,7 @@ class FilterConfigurationTest {
 
   @Test
   void shouldRegisterSignedDataFilterOnIssueApiEndpoints() {
-    SignedDataFilter filter = new SignedDataFilter(new ObjectMapper(), SIGNATURE_SECRET_KEY);
+    SignedDataFilter filter = new SignedDataFilter(new ObjectMapper(), SIGNATURE_SECRET_KEY, null);
 
     var registrationBean = configuration.registerSignedDataFilter(filter);
 
@@ -66,7 +66,7 @@ class FilterConfigurationTest {
 
   @Test
   void shouldRegisterSignedDataFilterOnVerifyApiEndpoints() {
-    SignedDataFilter filter = new SignedDataFilter(new ObjectMapper(), SIGNATURE_SECRET_KEY);
+    SignedDataFilter filter = new SignedDataFilter(new ObjectMapper(), SIGNATURE_SECRET_KEY, null);
 
     var registrationBean = configuration.registerSignedDataFilter(filter);
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationServiceTest.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.nhs.hee.tis.trainee.credentials.model.ModificationMetadata;
+import uk.nhs.hee.tis.trainee.credentials.repository.ModificationMetadataRepository;
+
+class RevocationServiceTest {
+
+  private RevocationService service;
+  private ModificationMetadataRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    repository = mock(ModificationMetadataRepository.class);
+    service = new RevocationService(repository);
+  }
+
+  @Test
+  void shouldReturnPresentLastModifiedWhenMetadataFound() {
+    Instant now = Instant.now();
+    ModificationMetadata metadata = new ModificationMetadata("", null, now);
+    when(repository.findById(any())).thenReturn(Optional.of(metadata));
+
+    Optional<Instant> lastModifiedDate = service.getLastModifiedDate("", null);
+
+    assertThat("Unexpected last modified date presence", lastModifiedDate.isPresent(), is(true));
+    assertThat("Unexpected last modified date", lastModifiedDate.get(), is(now));
+  }
+
+  @Test
+  void shouldReturnEmptyLastModifiedWhenMetadataNotFound() {
+    when(repository.findById(any())).thenReturn(Optional.empty());
+
+    Optional<Instant> lastModifiedDate = service.getLastModifiedDate("", null);
+
+    assertThat("Unexpected last modified date presence", lastModifiedDate.isEmpty(), is(true));
+  }
+}


### PR DESCRIPTION
Signed data is currently trusted to always be accurate, with the signature valid for a set length of time.

Add an additional check to the `SignedDataFilter` to ensure that signed data is rejected if the underlying data was modified after signing.

Create a RevocationService function to get the last modified data for a given credential type and TIS ID combination.

TIS21-4128
TIS21-4304