### PR TITLE
chore: add task role to defintion template

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -119,6 +119,7 @@
     "FARGATE"
   ],
   "executionRoleArn": "ecsTaskExecutionRole",
+  "taskRoleArn": "tis-trainee-credentials_task-role_${environment}",
   "networkMode": "awsvpc",
   "cpu": "256",
   "memory": "512"


### PR DESCRIPTION
A task role is required to give permissions for the SQS queue listeners, add a task role to the task definition template.

TIS21-4128
TIS21-4303