### PR TITLE
feat: store last modified timestamp during revoke 

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/CredentialType.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/CredentialType.java
@@ -31,20 +31,22 @@ import lombok.Getter;
 @Getter
 public enum CredentialType {
 
-  TRAINING_PLACEMENT("issue.TrainingPlacement", "/api/issue/placement"),
-  TRAINING_PROGRAMME("issue.TrainingProgramme", "/api/issue/programme-membership");
+  TRAINING_PLACEMENT("TrainingPlacement", "/api/issue/placement"),
+  TRAINING_PROGRAMME("TrainingProgramme", "/api/issue/programme-membership");
 
-  private final String gatewayScope;
+  private static final String ISSUANCE_SCOPE_PREFIX = "issue.";
+
+  private final String templateName;
   private final String apiPath;
 
   /**
    * Construct a credential type.
    *
-   * @param gatewayScope The gateway scope e.g. issue.DataType.
+   * @param templateName The gateway credential template name.
    * @param apiPath      The API request path for the credential type.
    */
-  CredentialType(String gatewayScope, String apiPath) {
-    this.gatewayScope = gatewayScope;
+  CredentialType(String templateName, String apiPath) {
+    this.templateName = templateName;
     this.apiPath = apiPath;
   }
 
@@ -58,5 +60,14 @@ public enum CredentialType {
     return Arrays.stream(CredentialType.values())
         .filter(ct -> ct.apiPath.equals(apiPath))
         .findFirst();
+  }
+
+  /**
+   * Get issuance scope e.g. issue.TemplateName
+   *
+   * @return The issuance scope.
+   */
+  public String getIssuanceScope() {
+    return ISSUANCE_SCOPE_PREFIX + templateName;
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/DeleteEventDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/DeleteEventDto.java
@@ -23,13 +23,15 @@ package uk.nhs.hee.tis.trainee.credentials.dto;
 
 import jakarta.validation.constraints.NotEmpty;
 import java.io.Serializable;
+import java.time.Instant;
 
 /**
  * A DTO representing data deletion events.
  *
- * @param tisId The id of the record.
+ * @param tisId     The id of the record.
+ * @param timestamp The timestamp of the deletion.
  */
 public record DeleteEventDto(
-    @NotEmpty String tisId) implements Serializable {
+    @NotEmpty String tisId, Instant timestamp) implements Serializable {
 
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/PlacementCredentialDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/PlacementCredentialDto.java
@@ -72,7 +72,7 @@ public record PlacementCredentialDto(
 
   @Override
   public String getScope() {
-    return CredentialType.TRAINING_PLACEMENT.getGatewayScope();
+    return CredentialType.TRAINING_PLACEMENT.getIssuanceScope();
   }
 
   @Override

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/ProgrammeMembershipCredentialDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/ProgrammeMembershipCredentialDto.java
@@ -56,7 +56,7 @@ public record ProgrammeMembershipCredentialDto(
 
   @Override
   public String getScope() {
-    return CredentialType.TRAINING_PROGRAMME.getGatewayScope();
+    return CredentialType.TRAINING_PROGRAMME.getIssuanceScope();
   }
 
   @Override

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/event/PlacementEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/event/PlacementEventListener.java
@@ -50,7 +50,8 @@ public class PlacementEventListener {
    */
   @SqsListener(value = "${application.aws.sqs.delete-placement}", deletionPolicy = ON_SUCCESS)
   void deletePlacement(DeleteEventDto deletedPlacement) {
-    log.debug("Received delete event for placement {}.", deletedPlacement);
-    revocationService.revoke(deletedPlacement.tisId(), CredentialType.TRAINING_PLACEMENT);
+    log.info("Received delete event for placement {}.", deletedPlacement);
+    revocationService.revoke(deletedPlacement.tisId(), CredentialType.TRAINING_PLACEMENT,
+        deletedPlacement.timestamp());
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/event/ProgrammeMembershipEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/event/ProgrammeMembershipEventListener.java
@@ -51,7 +51,8 @@ public class ProgrammeMembershipEventListener {
   @SqsListener(value = "${application.aws.sqs.delete-programme-membership}",
       deletionPolicy = ON_SUCCESS)
   void deleteProgrammeMembership(DeleteEventDto deletedProgrammeMembership) {
-    log.debug("Received delete event for programme membership {}.", deletedProgrammeMembership);
-    revocationService.revoke(deletedProgrammeMembership.tisId(), CredentialType.TRAINING_PROGRAMME);
+    log.info("Received delete event for programme membership {}.", deletedProgrammeMembership);
+    revocationService.revoke(deletedProgrammeMembership.tisId(), CredentialType.TRAINING_PROGRAMME,
+        deletedProgrammeMembership.timestamp());
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationService.java
@@ -75,9 +75,9 @@ public class RevocationService {
     //if it exists, then revoke it
     Optional<CredentialMetadata> metadata
         = credentialMetadataRepository.findByCredentialTypeAndTisId(
-        credentialType.getGatewayScope(), tisId);
+        credentialType.getIssuanceScope(), tisId);
     if (metadata.isPresent()) {
-      gatewayService.revokeCredential(credentialType.getGatewayScope(),
+      gatewayService.revokeCredential(credentialType.getIssuanceScope(),
           metadata.get().getCredentialId());
       //TODO: might need to remove 'issue.' from gateway scope?
       credentialMetadataRepository.deleteById(metadata.get().getCredentialId());

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationService.java
@@ -79,8 +79,9 @@ public class RevocationService {
     saveLastModifiedDate(tisId, credentialType, modifiedTimestamp);
 
     // Find this credential in the credential metadata repository. If it exists, then revoke it.
-    Optional<CredentialMetadata> metadata = credentialMetadataRepository.findByCredentialTypeAndTisId(
-        credentialType.getIssuanceScope(), tisId);
+    Optional<CredentialMetadata> metadata =
+        credentialMetadataRepository.findByCredentialTypeAndTisId(
+            credentialType.getIssuanceScope(), tisId);
     if (metadata.isPresent()) {
       log.info("Issued credential {} found for TIS ID {}, revoking.", credentialType, tisId);
       gatewayService.revokeCredential(credentialType.getTemplateName(),

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationService.java
@@ -83,8 +83,7 @@ public class RevocationService {
         credentialType.getIssuanceScope(), tisId);
     if (metadata.isPresent()) {
       log.info("Issued credential {} found for TIS ID {}, revoking.", credentialType, tisId);
-      //TODO: might need to remove 'issue.' from gateway scope?
-      gatewayService.revokeCredential(credentialType.getIssuanceScope(),
+      gatewayService.revokeCredential(credentialType.getTemplateName(),
           metadata.get().getCredentialId());
       credentialMetadataRepository.deleteById(metadata.get().getCredentialId());
       log.info("Credential {} for TIS ID {} has been revoked.", credentialType, tisId);

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/event/PlacementEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/event/PlacementEventListenerTest.java
@@ -21,9 +21,13 @@
 
 package uk.nhs.hee.tis.trainee.credentials.event;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,10 +50,29 @@ class PlacementEventListenerTest {
 
   @Test
   void shouldDeletePlacement() {
-    DeleteEventDto dto = new DeleteEventDto(TIS_ID);
+    DeleteEventDto dto = new DeleteEventDto(TIS_ID, null);
 
     listener.deletePlacement(dto);
 
-    verify(service).revoke(TIS_ID, CredentialType.TRAINING_PLACEMENT);
+    verify(service).revoke(eq(TIS_ID), eq(CredentialType.TRAINING_PLACEMENT), any());
+  }
+
+  @Test
+  void shouldPassNullTimestampWhenDeletingPlacementWithNoTimestamp() {
+    DeleteEventDto dto = new DeleteEventDto(TIS_ID, null);
+
+    listener.deletePlacement(dto);
+
+    verify(service).revoke(TIS_ID, CredentialType.TRAINING_PLACEMENT, null);
+  }
+
+  @Test
+  void shouldPassProvidedTimestampWhenDeletingPlacementWithTimestamp() {
+    Instant now = Instant.now().minus(Duration.ofDays(1));
+    DeleteEventDto dto = new DeleteEventDto(TIS_ID, now);
+
+    listener.deletePlacement(dto);
+
+    verify(service).revoke(TIS_ID, CredentialType.TRAINING_PLACEMENT, now);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/event/ProgrammeMembershipEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/event/ProgrammeMembershipEventListenerTest.java
@@ -21,9 +21,13 @@
 
 package uk.nhs.hee.tis.trainee.credentials.event;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,10 +50,29 @@ class ProgrammeMembershipEventListenerTest {
 
   @Test
   void shouldDeleteProgrammeMembership() {
-    DeleteEventDto dto = new DeleteEventDto(TIS_ID);
+    DeleteEventDto dto = new DeleteEventDto(TIS_ID, null);
 
     listener.deleteProgrammeMembership(dto);
 
-    verify(service).revoke(TIS_ID, CredentialType.TRAINING_PROGRAMME);
+    verify(service).revoke(eq(TIS_ID), eq(CredentialType.TRAINING_PROGRAMME), any());
+  }
+
+  @Test
+  void shouldPassNullTimestampWhenDeletingProgrammeMembershipWithNoTimestamp() {
+    DeleteEventDto dto = new DeleteEventDto(TIS_ID, null);
+
+    listener.deleteProgrammeMembership(dto);
+
+    verify(service).revoke(TIS_ID, CredentialType.TRAINING_PROGRAMME, null);
+  }
+
+  @Test
+  void shouldPassProvidedTimestampWhenDeletingProgrammeMembershipWithTimestamp() {
+    Instant now = Instant.now().minus(Duration.ofDays(1));
+    DeleteEventDto dto = new DeleteEventDto(TIS_ID, now);
+
+    listener.deleteProgrammeMembership(dto);
+
+    verify(service).revoke(TIS_ID, CredentialType.TRAINING_PROGRAMME, now);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayServiceTest.java
@@ -530,7 +530,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(REVOCATION_ENDPOINT), requestCaptor.capture(),
         eq(String.class))).thenReturn(ResponseEntity.ok().build());
 
-    service.revokeCredential(credentialType.getGatewayScope(), CREDENTIAL_ID);
+    service.revokeCredential(credentialType.getIssuanceScope(), CREDENTIAL_ID);
 
     HttpHeaders headers = requestCaptor.getValue().getHeaders();
     assertThat("Unexpected content type header.", headers.get(HttpHeaders.ACCEPT),
@@ -544,7 +544,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(REVOCATION_ENDPOINT), requestCaptor.capture(),
         eq(String.class))).thenReturn(ResponseEntity.ok().build());
 
-    service.revokeCredential(credentialType.getGatewayScope(), CREDENTIAL_ID);
+    service.revokeCredential(credentialType.getIssuanceScope(), CREDENTIAL_ID);
 
     HttpHeaders headers = requestCaptor.getValue().getHeaders();
     assertThat("Unexpected content type header.", headers.get(HttpHeaders.CONTENT_TYPE),
@@ -558,7 +558,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(REVOCATION_ENDPOINT), requestCaptor.capture(),
         eq(String.class))).thenReturn(ResponseEntity.ok().build());
 
-    service.revokeCredential(credentialType.getGatewayScope(), CREDENTIAL_ID);
+    service.revokeCredential(credentialType.getIssuanceScope(), CREDENTIAL_ID);
 
     var request = (HttpEntity<Map<String, String>>) requestCaptor.getValue();
     Map<String, String> requestBody = request.getBody();
@@ -572,7 +572,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(REVOCATION_ENDPOINT), requestCaptor.capture(),
         eq(String.class))).thenReturn(ResponseEntity.ok().build());
 
-    service.revokeCredential(credentialType.getGatewayScope(), CREDENTIAL_ID);
+    service.revokeCredential(credentialType.getIssuanceScope(), CREDENTIAL_ID);
 
     var request = (HttpEntity<Map<String, String>>) requestCaptor.getValue();
     Map<String, String> requestBody = request.getBody();
@@ -586,7 +586,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(REVOCATION_ENDPOINT), requestCaptor.capture(),
         eq(String.class))).thenReturn(ResponseEntity.ok().build());
 
-    service.revokeCredential(credentialType.getGatewayScope(), CREDENTIAL_ID);
+    service.revokeCredential(credentialType.getIssuanceScope(), CREDENTIAL_ID);
 
     var request = (HttpEntity<Map<String, String>>) requestCaptor.getValue();
     Map<String, String> requestBody = request.getBody();
@@ -600,12 +600,12 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(REVOCATION_ENDPOINT), requestCaptor.capture(),
         eq(String.class))).thenReturn(ResponseEntity.ok().build());
 
-    service.revokeCredential(credentialType.getGatewayScope(), CREDENTIAL_ID);
+    service.revokeCredential(credentialType.getIssuanceScope(), CREDENTIAL_ID);
 
     var request = (HttpEntity<Map<String, String>>) requestCaptor.getValue();
     Map<String, String> requestBody = request.getBody();
     assertThat("Unexpected client id.", requestBody.get("CredentialTemplateName"),
-        is(credentialType.getGatewayScope()));
+        is(credentialType.getIssuanceScope()));
   }
 
   @ParameterizedTest
@@ -615,7 +615,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(REVOCATION_ENDPOINT), requestCaptor.capture(),
         eq(String.class))).thenReturn(ResponseEntity.ok().build());
 
-    service.revokeCredential(credentialType.getGatewayScope(), CREDENTIAL_ID);
+    service.revokeCredential(credentialType.getIssuanceScope(), CREDENTIAL_ID);
 
     var request = (HttpEntity<Map<String, String>>) requestCaptor.getValue();
     Map<String, String> requestBody = request.getBody();
@@ -629,7 +629,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(REVOCATION_ENDPOINT), requestCaptor.capture(),
         eq(String.class))).thenReturn(ResponseEntity.ok().build());
 
-    service.revokeCredential(credentialType.getGatewayScope(), CREDENTIAL_ID);
+    service.revokeCredential(credentialType.getIssuanceScope(), CREDENTIAL_ID);
 
     var request = (HttpEntity<Map<String, String>>) requestCaptor.getValue();
     Map<String, String> requestBody = request.getBody();
@@ -645,7 +645,7 @@ class GatewayServiceTest {
         eq(String.class))).thenReturn(ResponseEntity.ok().build());
 
     assertDoesNotThrow(
-        () -> service.revokeCredential(credentialType.getGatewayScope(), CREDENTIAL_ID));
+        () -> service.revokeCredential(credentialType.getIssuanceScope(), CREDENTIAL_ID));
   }
 
   @ParameterizedTest
@@ -655,7 +655,7 @@ class GatewayServiceTest {
     when(restTemplate.postForEntity(eq(REVOCATION_ENDPOINT), requestCaptor.capture(),
         eq(String.class))).thenReturn(ResponseEntity.notFound().build());
 
-    String scope = credentialType.getGatewayScope();
+    String scope = credentialType.getIssuanceScope();
     ResponseStatusException exception = assertThrows(ResponseStatusException.class,
         () -> service.revokeCredential(scope, CREDENTIAL_ID));
     assertThat("Unexpected exception status code.", exception.getStatusCode(),

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationServiceTest.java
@@ -111,7 +111,7 @@ class RevocationServiceTest {
     when(credentialMetadataRepository.findByCredentialTypeAndTisId(scope, TIS_ID)).thenReturn(
         Optional.of(credentialMetadata));
     doThrow(ResponseStatusException.class).when(gatewayService)
-        .revokeCredential(scope, CREDENTIAL_ID);
+        .revokeCredential(credentialType.getTemplateName(), CREDENTIAL_ID);
 
     assertThrows(ResponseStatusException.class, () -> service.revoke(TIS_ID, credentialType, null));
 
@@ -133,7 +133,7 @@ class RevocationServiceTest {
 
     service.revoke(TIS_ID, credentialType, null);
 
-    verify(gatewayService).revokeCredential(scope, CREDENTIAL_ID);
+    verify(gatewayService).revokeCredential(credentialType.getTemplateName(), CREDENTIAL_ID);
     verify(credentialMetadataRepository).deleteById(CREDENTIAL_ID);
   }
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationServiceTest.java
@@ -88,8 +88,9 @@ class RevocationServiceTest {
   @ParameterizedTest
   @EnumSource(CredentialType.class)
   void shouldNotAttemptRevocationWhenCredentialNotIssued(CredentialType credentialType) {
-    when(credentialMetadataRepository.findByCredentialTypeAndTisId(credentialType.getGatewayScope(),
-        TIS_ID)).thenReturn(Optional.empty());
+    when(
+        credentialMetadataRepository.findByCredentialTypeAndTisId(credentialType.getIssuanceScope(),
+            TIS_ID)).thenReturn(Optional.empty());
 
     service.revoke(TIS_ID, credentialType);
 
@@ -103,7 +104,7 @@ class RevocationServiceTest {
     credentialMetadata.setTisId(TIS_ID);
     credentialMetadata.setCredentialId(CREDENTIAL_ID);
 
-    String scope = credentialType.getGatewayScope();
+    String scope = credentialType.getIssuanceScope();
 
     when(credentialMetadataRepository.findByCredentialTypeAndTisId(scope, TIS_ID)).thenReturn(
         Optional.of(credentialMetadata));
@@ -123,7 +124,7 @@ class RevocationServiceTest {
     credentialMetadata.setTisId(TIS_ID);
     credentialMetadata.setCredentialId(CREDENTIAL_ID);
 
-    String scope = credentialType.getGatewayScope();
+    String scope = credentialType.getIssuanceScope();
 
     when(credentialMetadataRepository.findByCredentialTypeAndTisId(scope, TIS_ID)).thenReturn(
         Optional.of(credentialMetadata));

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationServiceTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
@@ -39,6 +40,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
 import org.springframework.web.server.ResponseStatusException;
 import uk.nhs.hee.tis.trainee.credentials.dto.CredentialType;
 import uk.nhs.hee.tis.trainee.credentials.model.CredentialMetadata;
@@ -92,7 +94,7 @@ class RevocationServiceTest {
         credentialMetadataRepository.findByCredentialTypeAndTisId(credentialType.getIssuanceScope(),
             TIS_ID)).thenReturn(Optional.empty());
 
-    service.revoke(TIS_ID, credentialType);
+    service.revoke(TIS_ID, credentialType, null);
 
     verifyNoInteractions(gatewayService);
   }
@@ -111,7 +113,7 @@ class RevocationServiceTest {
     doThrow(ResponseStatusException.class).when(gatewayService)
         .revokeCredential(scope, CREDENTIAL_ID);
 
-    assertThrows(ResponseStatusException.class, () -> service.revoke(TIS_ID, credentialType));
+    assertThrows(ResponseStatusException.class, () -> service.revoke(TIS_ID, credentialType, null));
 
     verify(credentialMetadataRepository).findByCredentialTypeAndTisId(scope, TIS_ID);
     verifyNoMoreInteractions(credentialMetadataRepository);
@@ -129,9 +131,53 @@ class RevocationServiceTest {
     when(credentialMetadataRepository.findByCredentialTypeAndTisId(scope, TIS_ID)).thenReturn(
         Optional.of(credentialMetadata));
 
-    service.revoke(TIS_ID, credentialType);
+    service.revoke(TIS_ID, credentialType, null);
 
     verify(gatewayService).revokeCredential(scope, CREDENTIAL_ID);
     verify(credentialMetadataRepository).deleteById(CREDENTIAL_ID);
+  }
+
+  @ParameterizedTest
+  @EnumSource(CredentialType.class)
+  void shouldStoreLastModifiedDateWhenRevoking(CredentialType credentialType) {
+    service.revoke(TIS_ID, credentialType, null);
+
+    ArgumentCaptor<ModificationMetadata> metadataCaptor = ArgumentCaptor.forClass(
+        ModificationMetadata.class);
+    verify(repository).save(metadataCaptor.capture());
+
+    ModificationMetadata metadata = metadataCaptor.getValue();
+    assertThat("Unexpected TIS ID.", metadata.id().tisId(), is(TIS_ID));
+    assertThat("Unexpected credential type.", metadata.id().credentialType(), is(credentialType));
+  }
+
+  @ParameterizedTest
+  @EnumSource(CredentialType.class)
+  void shouldStoreLastModifiedDateAsNowWhenTimestampNull(CredentialType credentialType) {
+    service.revoke(TIS_ID, credentialType, null);
+
+    ArgumentCaptor<ModificationMetadata> metadataCaptor = ArgumentCaptor.forClass(
+        ModificationMetadata.class);
+    verify(repository).save(metadataCaptor.capture());
+
+    ModificationMetadata metadata = metadataCaptor.getValue();
+    Instant timestamp = metadata.lastModifiedDate();
+    Instant now = Instant.now();
+    int delta = (int) Duration.between(timestamp, now).toMinutes();
+    assertThat("Unexpected modification timestamp delta.", delta, is(0));
+  }
+
+  @ParameterizedTest
+  @EnumSource(CredentialType.class)
+  void shouldStoreLastModifiedDateAsGivenWhenTimestampNotNull(CredentialType credentialType) {
+    Instant now = Instant.now().minus(Duration.ofDays(1));
+    service.revoke(TIS_ID, credentialType, now);
+
+    ArgumentCaptor<ModificationMetadata> metadataCaptor = ArgumentCaptor.forClass(
+        ModificationMetadata.class);
+    verify(repository).save(metadataCaptor.capture());
+
+    ModificationMetadata metadata = metadataCaptor.getValue();
+    assertThat("Unexpected modification timestamp.", metadata.lastModifiedDate(), is(now));
   }
 }


### PR DESCRIPTION
Signature invalidation requires a timestamp of the last modification
made to an piece of data.
Update the revocation service to store the timestamp of the modification
before revoking the credential. If no timestamp is given then the
current date/time should be used.

TIS21-4128
TIS21-4304