### PR TITLE
feat: revoke credentials for updated records

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -83,6 +83,14 @@
         {
           "name": "DELETE_PROGRAMME_MEMBERSHIP_QUEUE_URL",
           "valueFrom": "/tis/trainee/sync/${environment}/queue-url/delete-programme-membership"
+        },
+        {
+          "name": "UPDATE_PLACEMENT_QUEUE_URL",
+          "valueFrom": "/tis/trainee/sync/${environment}/queue-url/update-placement"
+        },
+        {
+          "name": "UPDATE_PROGRAMME_MEMBERSHIP_QUEUE_URL",
+          "valueFrom": "/tis/trainee/sync/${environment}/queue-url/update-programme-membership"
         }
       ],
       "logConfiguration": {

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.12.1"
+version = "0.13.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/RecordDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/RecordDto.java
@@ -1,0 +1,39 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.Collections;
+import java.util.Map;
+import lombok.Data;
+
+/**
+ * A DTO representing data records, as they are received and passed-on by tis-trainee-sync.
+ */
+@Data
+public class RecordDto {
+
+  private Map<String, String> data = Collections.emptyMap();
+
+  @NotNull
+  private Map<String, String> metadata;
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/UpdateEventDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/UpdateEventDto.java
@@ -23,16 +23,14 @@ package uk.nhs.hee.tis.trainee.credentials.dto;
 
 import jakarta.validation.constraints.NotEmpty;
 import java.io.Serializable;
-import java.time.Instant;
 
 /**
  * A DTO representing data update events.
  *
  * @param tisId     The id of the record.
- * @param timestamp The timestamp of the deletion.
  * @
  */
 public record UpdateEventDto(
-    @NotEmpty String tisId, Instant timestamp, RecordDto recrd) implements Serializable {
+    @NotEmpty String tisId, RecordDto record) implements Serializable {
 
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/UpdateEventDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/UpdateEventDto.java
@@ -21,16 +21,16 @@
 
 package uk.nhs.hee.tis.trainee.credentials.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotEmpty;
 import java.io.Serializable;
 
 /**
  * A DTO representing data update events.
  *
- * @param tisId     The id of the record.
- * @
+ * @param tisId The id of the record.
  */
 public record UpdateEventDto(
-    @NotEmpty String tisId, RecordDto record) implements Serializable {
+    @NotEmpty String tisId, @JsonProperty("record") RecordDto recrd) implements Serializable {
 
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/UpdateEventDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/UpdateEventDto.java
@@ -1,0 +1,38 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import java.io.Serializable;
+import java.time.Instant;
+
+/**
+ * A DTO representing data update events.
+ *
+ * @param tisId     The id of the record.
+ * @param timestamp The timestamp of the deletion.
+ * @
+ */
+public record UpdateEventDto(
+    @NotEmpty String tisId, Instant timestamp, RecordDto recrd) implements Serializable {
+
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/event/PlacementEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/event/PlacementEventListener.java
@@ -28,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.trainee.credentials.dto.CredentialType;
 import uk.nhs.hee.tis.trainee.credentials.dto.DeleteEventDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.UpdateEventDto;
 import uk.nhs.hee.tis.trainee.credentials.service.RevocationService;
 
 /**
@@ -52,5 +53,19 @@ public class PlacementEventListener {
   void deletePlacement(DeleteEventDto deletedPlacement) {
     log.info("Received delete event for placement {}.", deletedPlacement);
     revocationService.revoke(deletedPlacement.tisId(), CredentialType.TRAINING_PLACEMENT);
+  }
+
+  /**
+   * Listener for update events.
+   *
+   * @param updatedPlacement The updated placement.
+   */
+  @SqsListener(value = "${application.aws.sqs.update-placement}", deletionPolicy = ON_SUCCESS)
+  void updatePlacement(UpdateEventDto updatedPlacement) {
+    log.info("Received update event for placement {}.", updatedPlacement);
+    // TODO be selective with revoking credentials depending on the actual data changed.
+    // For now, we simply revoke
+    revocationService.revoke(updatedPlacement.tisId(), CredentialType.TRAINING_PLACEMENT,
+        updatedPlacement.timestamp());
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/event/PlacementEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/event/PlacementEventListener.java
@@ -63,9 +63,7 @@ public class PlacementEventListener {
   @SqsListener(value = "${application.aws.sqs.update-placement}", deletionPolicy = ON_SUCCESS)
   void updatePlacement(UpdateEventDto updatedPlacement) {
     log.info("Received update event for placement {}.", updatedPlacement);
-    // TODO be selective with revoking credentials depending on the actual data changed.
-    // For now, we simply revoke
-    revocationService.revoke(updatedPlacement.tisId(), CredentialType.TRAINING_PLACEMENT,
-        updatedPlacement.timestamp());
+    // For now, we simply revoke regardless of which fields have updated (pending TIS21-4152)
+    revocationService.revoke(updatedPlacement.tisId(), CredentialType.TRAINING_PLACEMENT);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/event/ProgrammeMembershipEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/event/ProgrammeMembershipEventListener.java
@@ -28,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.trainee.credentials.dto.CredentialType;
 import uk.nhs.hee.tis.trainee.credentials.dto.DeleteEventDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.UpdateEventDto;
 import uk.nhs.hee.tis.trainee.credentials.service.RevocationService;
 
 /**
@@ -53,5 +54,20 @@ public class ProgrammeMembershipEventListener {
   void deleteProgrammeMembership(DeleteEventDto deletedProgrammeMembership) {
     log.info("Received delete event for programme membership {}.", deletedProgrammeMembership);
     revocationService.revoke(deletedProgrammeMembership.tisId(), CredentialType.TRAINING_PROGRAMME);
+  }
+
+
+  /**
+   * Listener for update events.
+   *
+   * @param updatedProgrammeMembership The updated programme membership.
+   */
+  @SqsListener(value = "${application.aws.sqs.update-programme-membership}", deletionPolicy = ON_SUCCESS)
+  void updateProgrammeMembership(UpdateEventDto updatedProgrammeMembership) {
+    log.info("Received update event for programme membership {}.", updatedProgrammeMembership);
+    // TODO be selective with revoking credentials depending on the actual data changed.
+    // For now, we simply revoke
+    revocationService.revoke(updatedProgrammeMembership.tisId(), CredentialType.TRAINING_PROGRAMME,
+        updatedProgrammeMembership.timestamp());
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/event/ProgrammeMembershipEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/event/ProgrammeMembershipEventListener.java
@@ -62,7 +62,8 @@ public class ProgrammeMembershipEventListener {
    *
    * @param updatedProgrammeMembership The updated programme membership.
    */
-  @SqsListener(value = "${application.aws.sqs.update-programme-membership}", deletionPolicy = ON_SUCCESS)
+  @SqsListener(value = "${application.aws.sqs.update-programme-membership}",
+      deletionPolicy = ON_SUCCESS)
   void updateProgrammeMembership(UpdateEventDto updatedProgrammeMembership) {
     log.info("Received update event for programme membership {}.", updatedProgrammeMembership);
     // For now, we simply revoke regardless of which fields have updated (pending TIS21-4152)

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/event/ProgrammeMembershipEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/event/ProgrammeMembershipEventListener.java
@@ -65,9 +65,7 @@ public class ProgrammeMembershipEventListener {
   @SqsListener(value = "${application.aws.sqs.update-programme-membership}", deletionPolicy = ON_SUCCESS)
   void updateProgrammeMembership(UpdateEventDto updatedProgrammeMembership) {
     log.info("Received update event for programme membership {}.", updatedProgrammeMembership);
-    // TODO be selective with revoking credentials depending on the actual data changed.
-    // For now, we simply revoke
-    revocationService.revoke(updatedProgrammeMembership.tisId(), CredentialType.TRAINING_PROGRAMME,
-        updatedProgrammeMembership.timestamp());
+    // For now, we simply revoke regardless of which fields have updated (pending TIS21-4152)
+    revocationService.revoke(updatedProgrammeMembership.tisId(), CredentialType.TRAINING_PROGRAMME);
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,8 @@ application:
     sqs:
       delete-placement: ${DELETE_PLACEMENT_QUEUE_URL:}
       delete-programme-membership: ${DELETE_PROGRAMME_MEMBERSHIP_QUEUE_URL:}
+      update-placement: ${UPDATE_PLACEMENT_QUEUE_URL:}
+      update-programme-membership: ${UPDATE_PROGRAMME_MEMBERSHIP_QUEUE_URL:}
   cache:
     key-prefix: Credentials
     time-to-live:

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/event/PlacementEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/event/PlacementEventListenerTest.java
@@ -57,29 +57,10 @@ class PlacementEventListenerTest {
 
   @Test
   void shouldUpdatePlacement() {
-    UpdateEventDto dto = new UpdateEventDto(TIS_ID, null, null);
+    UpdateEventDto dto = new UpdateEventDto(TIS_ID, null);
 
     listener.updatePlacement(dto);
 
     verify(service).revoke(eq(TIS_ID), eq(CredentialType.TRAINING_PLACEMENT), any());
-  }
-
-  @Test
-  void shouldPassNullTimestampWhenUpdatingPlacementWithNoTimestamp() {
-    UpdateEventDto dto = new UpdateEventDto(TIS_ID, null, null);
-
-    listener.updatePlacement(dto);
-
-    verify(service).revoke(TIS_ID, CredentialType.TRAINING_PLACEMENT, null);
-  }
-
-  @Test
-  void shouldPassProvidedTimestampWhenUpdatingPlacementWithTimestamp() {
-    Instant now = Instant.now().minus(Duration.ofDays(1));
-    UpdateEventDto dto = new UpdateEventDto(TIS_ID, now, null);
-
-    listener.updatePlacement(dto);
-
-    verify(service).revoke(TIS_ID, CredentialType.TRAINING_PLACEMENT, now);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/event/PlacementEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/event/PlacementEventListenerTest.java
@@ -61,6 +61,6 @@ class PlacementEventListenerTest {
 
     listener.updatePlacement(dto);
 
-    verify(service).revoke(eq(TIS_ID), eq(CredentialType.TRAINING_PLACEMENT), any());
+    verify(service).revoke(eq(TIS_ID), eq(CredentialType.TRAINING_PLACEMENT));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/event/PlacementEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/event/PlacementEventListenerTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.nhs.hee.tis.trainee.credentials.dto.CredentialType;
 import uk.nhs.hee.tis.trainee.credentials.dto.DeleteEventDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.UpdateEventDto;
 import uk.nhs.hee.tis.trainee.credentials.service.RevocationService;
 
 class PlacementEventListenerTest {
@@ -52,5 +53,33 @@ class PlacementEventListenerTest {
     listener.deletePlacement(dto);
 
     verify(service).revoke(TIS_ID, CredentialType.TRAINING_PLACEMENT);
+  }
+
+  @Test
+  void shouldUpdatePlacement() {
+    UpdateEventDto dto = new UpdateEventDto(TIS_ID, null, null);
+
+    listener.updatePlacement(dto);
+
+    verify(service).revoke(eq(TIS_ID), eq(CredentialType.TRAINING_PLACEMENT), any());
+  }
+
+  @Test
+  void shouldPassNullTimestampWhenUpdatingPlacementWithNoTimestamp() {
+    UpdateEventDto dto = new UpdateEventDto(TIS_ID, null, null);
+
+    listener.updatePlacement(dto);
+
+    verify(service).revoke(TIS_ID, CredentialType.TRAINING_PLACEMENT, null);
+  }
+
+  @Test
+  void shouldPassProvidedTimestampWhenUpdatingPlacementWithTimestamp() {
+    Instant now = Instant.now().minus(Duration.ofDays(1));
+    UpdateEventDto dto = new UpdateEventDto(TIS_ID, now, null);
+
+    listener.updatePlacement(dto);
+
+    verify(service).revoke(TIS_ID, CredentialType.TRAINING_PLACEMENT, now);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/event/PlacementEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/event/PlacementEventListenerTest.java
@@ -21,7 +21,6 @@
 
 package uk.nhs.hee.tis.trainee.credentials.event;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -61,6 +60,6 @@ class PlacementEventListenerTest {
 
     listener.updatePlacement(dto);
 
-    verify(service).revoke(eq(TIS_ID), eq(CredentialType.TRAINING_PLACEMENT));
+    verify(service).revoke(TIS_ID, CredentialType.TRAINING_PLACEMENT);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/event/ProgrammeMembershipEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/event/ProgrammeMembershipEventListenerTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.nhs.hee.tis.trainee.credentials.dto.CredentialType;
 import uk.nhs.hee.tis.trainee.credentials.dto.DeleteEventDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.UpdateEventDto;
 import uk.nhs.hee.tis.trainee.credentials.service.RevocationService;
 
 class ProgrammeMembershipEventListenerTest {
@@ -52,5 +53,33 @@ class ProgrammeMembershipEventListenerTest {
     listener.deleteProgrammeMembership(dto);
 
     verify(service).revoke(TIS_ID, CredentialType.TRAINING_PROGRAMME);
+  }
+
+  @Test
+  void shouldUpdateProgrammeMembership() {
+    UpdateEventDto dto = new UpdateEventDto(TIS_ID, null, null);
+
+    listener.updateProgrammeMembership(dto);
+
+    verify(service).revoke(eq(TIS_ID), eq(CredentialType.TRAINING_PROGRAMME), any());
+  }
+
+  @Test
+  void shouldPassNullTimestampWhenUpdatingProgrammeMembershipWithNoTimestamp() {
+    UpdateEventDto dto = new UpdateEventDto(TIS_ID, null, null);
+
+    listener.updateProgrammeMembership(dto);
+
+    verify(service).revoke(TIS_ID, CredentialType.TRAINING_PROGRAMME, null);
+  }
+
+  @Test
+  void shouldPassProvidedTimestampWhenUpdatingProgrammeMembershipWithTimestamp() {
+    Instant now = Instant.now().minus(Duration.ofDays(1));
+    UpdateEventDto dto = new UpdateEventDto(TIS_ID, now, null);
+
+    listener.updateProgrammeMembership(dto);
+
+    verify(service).revoke(TIS_ID, CredentialType.TRAINING_PROGRAMME, now);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/event/ProgrammeMembershipEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/event/ProgrammeMembershipEventListenerTest.java
@@ -61,6 +61,6 @@ class ProgrammeMembershipEventListenerTest {
 
     listener.updateProgrammeMembership(dto);
 
-    verify(service).revoke(eq(TIS_ID), eq(CredentialType.TRAINING_PROGRAMME), any());
+    verify(service).revoke(eq(TIS_ID), eq(CredentialType.TRAINING_PROGRAMME));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/event/ProgrammeMembershipEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/event/ProgrammeMembershipEventListenerTest.java
@@ -57,29 +57,10 @@ class ProgrammeMembershipEventListenerTest {
 
   @Test
   void shouldUpdateProgrammeMembership() {
-    UpdateEventDto dto = new UpdateEventDto(TIS_ID, null, null);
+    UpdateEventDto dto = new UpdateEventDto(TIS_ID, null);
 
     listener.updateProgrammeMembership(dto);
 
     verify(service).revoke(eq(TIS_ID), eq(CredentialType.TRAINING_PROGRAMME), any());
-  }
-
-  @Test
-  void shouldPassNullTimestampWhenUpdatingProgrammeMembershipWithNoTimestamp() {
-    UpdateEventDto dto = new UpdateEventDto(TIS_ID, null, null);
-
-    listener.updateProgrammeMembership(dto);
-
-    verify(service).revoke(TIS_ID, CredentialType.TRAINING_PROGRAMME, null);
-  }
-
-  @Test
-  void shouldPassProvidedTimestampWhenUpdatingProgrammeMembershipWithTimestamp() {
-    Instant now = Instant.now().minus(Duration.ofDays(1));
-    UpdateEventDto dto = new UpdateEventDto(TIS_ID, now, null);
-
-    listener.updateProgrammeMembership(dto);
-
-    verify(service).revoke(TIS_ID, CredentialType.TRAINING_PROGRAMME, now);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/event/ProgrammeMembershipEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/event/ProgrammeMembershipEventListenerTest.java
@@ -21,7 +21,6 @@
 
 package uk.nhs.hee.tis.trainee.credentials.event;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -61,6 +60,6 @@ class ProgrammeMembershipEventListenerTest {
 
     listener.updateProgrammeMembership(dto);
 
-    verify(service).revoke(eq(TIS_ID), eq(CredentialType.TRAINING_PROGRAMME));
+    verify(service).revoke(TIS_ID, CredentialType.TRAINING_PROGRAMME);
   }
 }


### PR DESCRIPTION
I'm putting this up for review though I believe there is a (permissions?) issue with tis-trainee-sync getting the messages through, which might make testing on stage a bit tricky for now. It does seem to work locally though with a message like

`awslocal sqs send-message --queue-url http://localhost:4566/queue/tis-trainee-sync-local-update-placement --message-body '{"tisId":"1538788", "record":{"data":{},"metadata":{}}}'`

TIS21-4151