### PR TITLE
Feat/revoke new credentials when data changed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.11.0"
+version = "0.12.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/CredentialDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/CredentialDto.java
@@ -53,4 +53,12 @@ public interface CredentialDto extends Serializable {
    */
   @JsonIgnore
   String getScope();
+
+  /**
+   * Get internal credential type.
+   *
+   * @return The credential's type.
+   */
+  @JsonIgnore
+  CredentialType getCredentialType();
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/PlacementCredentialDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/PlacementCredentialDto.java
@@ -76,6 +76,11 @@ public record PlacementCredentialDto(
   }
 
   @Override
+  public CredentialType getCredentialType() {
+    return CredentialType.TRAINING_PLACEMENT;
+  }
+
+  @Override
   public String getTisId() {
     return tisId;
   }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/ProgrammeMembershipCredentialDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/ProgrammeMembershipCredentialDto.java
@@ -60,6 +60,11 @@ public record ProgrammeMembershipCredentialDto(
   }
 
   @Override
+  public CredentialType getCredentialType() {
+    return CredentialType.TRAINING_PROGRAMME;
+  }
+
+  @Override
   public String getTisId() {
     return tisId;
   }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegate.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegate.java
@@ -26,6 +26,7 @@ import static uk.nhs.hee.tis.trainee.credentials.config.CacheConfiguration.VERIF
 import static uk.nhs.hee.tis.trainee.credentials.config.CacheConfiguration.VERIFIED_SESSION_DATA;
 
 import java.security.PublicKey;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.cache.annotation.CacheEvict;
@@ -46,6 +47,7 @@ class CachingDelegate {
   private static final String CODE_VERIFIER = "CodeVerifier";
   private static final String CREDENTIAL_DATA = "CredentialData";
   private static final String IDENTITY_DATA = "IdentityData";
+  private static final String ISSUANCE_TIMESTAMP = "IssuanceTimestamp";
   private static final String PUBLIC_KEY = "PublicKey";
   private static final String TRAINEE_ID = "TraineeIdentifier";
   private static final String UNVERIFIED_SESSION_IDENTIFIER = "SessionIdentifier::Unverified";
@@ -96,6 +98,30 @@ class CachingDelegate {
   @Cacheable(cacheNames = CREDENTIAL_DATA, cacheManager = CREDENTIAL_METADATA)
   @CacheEvict(CREDENTIAL_DATA)
   public Optional<CredentialDto> getCredentialData(UUID key) {
+    return Optional.empty();
+  }
+
+  /**
+   * Cache an issuance timestamp for later retrieval.
+   *
+   * @param key       The cache key.
+   * @param timestamp The issuance timestamp to cache.
+   * @return The cached issuance timestamp.
+   */
+  @CachePut(cacheNames = ISSUANCE_TIMESTAMP, cacheManager = CREDENTIAL_METADATA, key = "#key")
+  public Instant cacheIssuanceTimestamp(UUID key, Instant timestamp) {
+    return timestamp;
+  }
+
+  /**
+   * Get the issuance timestamp associated with the given key, any cached value will be removed.
+   *
+   * @param key The cache key.
+   * @return The cached issuance timestamp, or an empty optional if not found.
+   */
+  @Cacheable(cacheNames = ISSUANCE_TIMESTAMP, cacheManager = CREDENTIAL_METADATA)
+  @CacheEvict(ISSUANCE_TIMESTAMP)
+  public Optional<Instant> getIssuanceTimestamp(UUID key) {
     return Optional.empty();
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/IssuanceService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/IssuanceService.java
@@ -73,13 +73,13 @@ public class IssuanceService {
    * Start the issuance of a credential.
    *
    * @param authToken   The request's authorization token.
-   * @param dto         The user's identity data.
+   * @param dto         The user's credential data.
    * @param clientState The state sent by client when making the request to start verification.
    * @return The URI to continue the issuing via credential gateway, or empty if issuing failed.
    */
   public Optional<URI> startCredentialIssuance(String authToken, CredentialDto dto,
       @Nullable String clientState) {
-    // Cache the provided identity data against the nonce.
+    // Cache the provided credential data against the nonce.
     UUID nonce = UUID.randomUUID();
     cachingDelegate.cacheCredentialData(nonce, dto);
 
@@ -91,6 +91,9 @@ public class IssuanceService {
     Claims authClaims = jwtService.getClaims(authToken);
     String traineeId = authClaims.get("custom:tisId", String.class);
     cachingDelegate.cacheTraineeIdentifier(internalState, traineeId);
+
+    // Cache the current timestamp as the start of the issuance.
+    cachingDelegate.cacheIssuanceTimestamp(internalState, Instant.now());
 
     return gatewayService.getCredentialUri(dto, nonce.toString(), internalState.toString());
   }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationService.java
@@ -77,7 +77,16 @@ public class RevocationService {
   public void revoke(String tisId, CredentialType credentialType,
       @Nullable Instant modifiedTimestamp) {
     saveLastModifiedDate(tisId, credentialType, modifiedTimestamp);
+    revoke(tisId, credentialType);
+  }
 
+  /**
+   * Revoke any issued credentials for matching credential type and ID.
+   *
+   * @param tisId          The TIS ID of the modified object.
+   * @param credentialType The credential type of the modified object.
+   */
+  private void revoke(String tisId, CredentialType credentialType) {
     // Find this credential in the credential metadata repository. If it exists, then revoke it.
     Optional<CredentialMetadata> metadata =
         credentialMetadataRepository.findByCredentialTypeAndTisId(
@@ -91,6 +100,25 @@ public class RevocationService {
     } else {
       log.info("No {} credential issued for TIS ID {}, skipped revocation.", credentialType, tisId);
     }
+  }
+
+  /**
+   * Revoke a credential if it's data is stale.
+   *
+   * @param tisId          The TIS ID of the modified object.
+   * @param credentialType The credential type of the modified object.
+   * @param since          The timestamp to check for modifications since.
+   * @return Whether the data was stale and revoked.
+   */
+  public boolean revokeIfStale(String tisId, CredentialType credentialType, Instant since) {
+    Optional<Instant> lastModifiedDate = getLastModifiedDate(tisId, credentialType);
+
+    if (lastModifiedDate.isPresent() && lastModifiedDate.get().isAfter(since)) {
+      revoke(tisId, credentialType);
+      return true;
+    }
+
+    return false;
   }
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationService.java
@@ -105,16 +105,19 @@ public class RevocationService {
   /**
    * Revoke a credential if it's data is stale.
    *
+   * @param credentialId   The credential serial number.
    * @param tisId          The TIS ID of the modified object.
    * @param credentialType The credential type of the modified object.
    * @param since          The timestamp to check for modifications since.
    * @return Whether the data was stale and revoked.
    */
-  public boolean revokeIfStale(String tisId, CredentialType credentialType, Instant since) {
+  public boolean revokeIfStale(String credentialId, String tisId, CredentialType credentialType,
+      Instant since) {
     Optional<Instant> lastModifiedDate = getLastModifiedDate(tisId, credentialType);
 
     if (lastModifiedDate.isPresent() && lastModifiedDate.get().isAfter(since)) {
-      revoke(tisId, credentialType);
+      log.info("Issued credential {} found for TIS ID {}, revoking.", credentialType, tisId);
+      gatewayService.revokeCredential(credentialType.getTemplateName(), credentialId);
       return true;
     }
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/TestCredentialDto.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/TestCredentialDto.java
@@ -23,6 +23,7 @@ package uk.nhs.hee.tis.trainee.credentials;
 
 import java.time.Instant;
 import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialType;
 
 /**
  * An implementation of {@link CredentialDto} for test purposes.
@@ -42,5 +43,10 @@ public record TestCredentialDto(String tisId) implements CredentialDto {
   @Override
   public String getScope() {
     return "test.Credential";
+  }
+
+  @Override
+  public CredentialType getCredentialType() {
+    return null;
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegateIntegrationTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegateIntegrationTest.java
@@ -29,6 +29,7 @@ import io.awspring.cloud.autoconfigure.messaging.SqsAutoConfiguration;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import java.security.PublicKey;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
@@ -178,6 +179,48 @@ class CachingDelegateIntegrationTest {
     delegate.getCredentialData(key);
 
     Optional<CredentialDto> cachedOptional = delegate.getCredentialData(key);
+    assertThat("Unexpected cached value.", cachedOptional, is(Optional.empty()));
+  }
+
+  @Test
+  void shouldReturnEmptyIssuanceTimestampWhenNotCached() {
+    UUID key = UUID.randomUUID();
+
+    Optional<Instant> cachedOptional = delegate.getIssuanceTimestamp(key);
+    assertThat("Unexpected cached value.", cachedOptional, is(Optional.empty()));
+  }
+
+  @Test
+  void shouldReturnCachedIssuanceTimestampAfterCaching() {
+    UUID key = UUID.randomUUID();
+
+    Instant timestamp = Instant.now();
+    Instant cachedData = delegate.cacheIssuanceTimestamp(key, timestamp);
+    assertThat("Unexpected cached value.", cachedData, is(timestamp));
+  }
+
+  @Test
+  void shouldGetCachedIssuanceTimestampWhenCached() {
+    UUID key = UUID.randomUUID();
+
+    Instant timestamp = Instant.now();
+    delegate.cacheIssuanceTimestamp(key, timestamp);
+
+    Optional<Instant> cachedOptional = delegate.getIssuanceTimestamp(key);
+    assertThat("Unexpected cached value.", cachedOptional, is(Optional.of(timestamp)));
+  }
+
+  @Test
+  void shouldRemoveIssuanceTimestampWhenRetrieved() {
+    UUID key = UUID.randomUUID();
+
+    Instant timestamp = Instant.now();
+    delegate.cacheIssuanceTimestamp(key, timestamp);
+
+    // Ignore this result, the cached value should be evicted.
+    delegate.getIssuanceTimestamp(key);
+
+    Optional<Instant> cachedOptional = delegate.getIssuanceTimestamp(key);
     assertThat("Unexpected cached value.", cachedOptional, is(Optional.empty()));
   }
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegateTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/CachingDelegateTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import java.security.PublicKey;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
@@ -84,6 +85,19 @@ class CachingDelegateTest {
   }
 
   @Test
+  void shouldReturnCachedIssuanceTimestamp() {
+    Instant timestamp = Instant.now();
+    Instant cachedTimestamp = delegate.cacheIssuanceTimestamp(UUID.randomUUID(), timestamp);
+    assertThat("Unexpected issuance timestamp.", cachedTimestamp, is(timestamp));
+  }
+
+  @Test
+  void shouldGetEmptyIssuanceTimestamp() {
+    Optional<Instant> timestamp = delegate.getIssuanceTimestamp(UUID.randomUUID());
+    assertThat("Unexpected issuance timestamp.", timestamp, is(Optional.empty()));
+  }
+
+  @Test
   void shouldReturnCachedIdentityData() {
     IdentityDataDto identityData = new IdentityDataDto("Anthony", "Gilliam", LocalDate.now());
     IdentityDataDto returnValue = delegate.cacheIdentityData(UUID.randomUUID(), identityData);
@@ -129,7 +143,7 @@ class CachingDelegateTest {
   }
 
   @Test
-  void shouldGetEmptyunVerifiedSession() {
+  void shouldGetEmptyUnverifiedSession() {
     Optional<String> unverifiedSession = delegate.getUnverifiedSessionIdentifier(UUID.randomUUID());
     assertThat("Unexpected verified session.", unverifiedSession, is(Optional.empty()));
   }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/IssuanceServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/IssuanceServiceTest.java
@@ -354,8 +354,9 @@ class IssuanceServiceTest {
 
     when(cachingDelegate.getIssuanceTimestamp(UUID.fromString(STATE_VALUE))).thenReturn(
         Optional.empty());
-    when(revocationService.revokeIfStale(TIS_ID, credentialData.getCredentialType(),
-        Instant.MIN)).thenReturn(true);
+    when(revocationService.revokeIfStale(CREDENTIAL_ID, TIS_ID, credentialData.getCredentialType(),
+        Instant.MIN)).thenReturn(
+        true);
 
     URI uri = issuanceService.completeCredentialVerification(CODE_VALUE, STATE_VALUE, null, null);
 
@@ -382,7 +383,7 @@ class IssuanceServiceTest {
     Instant now = Instant.now();
     when(cachingDelegate.getIssuanceTimestamp(UUID.fromString(STATE_VALUE))).thenReturn(
         Optional.of(now));
-    when(revocationService.revokeIfStale(TIS_ID, credentialData.getCredentialType(),
+    when(revocationService.revokeIfStale(CREDENTIAL_ID, TIS_ID, credentialData.getCredentialType(),
         now)).thenReturn(true);
 
     URI uri = issuanceService.completeCredentialVerification(CODE_VALUE, STATE_VALUE, null, null);
@@ -410,7 +411,7 @@ class IssuanceServiceTest {
     Instant now = Instant.now();
     when(cachingDelegate.getIssuanceTimestamp(UUID.fromString(STATE_VALUE))).thenReturn(
         Optional.of(now));
-    when(revocationService.revokeIfStale(TIS_ID, credentialData.getCredentialType(),
+    when(revocationService.revokeIfStale(CREDENTIAL_ID, TIS_ID, credentialData.getCredentialType(),
         now)).thenReturn(false);
 
     URI uri = issuanceService.completeCredentialVerification(CODE_VALUE, STATE_VALUE, null, null);

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/JwtServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/JwtServiceTest.java
@@ -52,6 +52,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties.IssuingProperties.TokenProperties;
 import uk.nhs.hee.tis.trainee.credentials.dto.CredentialDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialType;
 import uk.nhs.hee.tis.trainee.credentials.dto.PlacementCredentialDto;
 import uk.nhs.hee.tis.trainee.credentials.dto.ProgrammeMembershipCredentialDto;
 
@@ -107,6 +108,11 @@ class JwtServiceTest {
       @Override
       public String getScope() {
         return "issue.Empty";
+      }
+
+      @Override
+      public CredentialType getCredentialType() {
+        return null;
       }
 
       @Override

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationServiceTest.java
@@ -149,7 +149,7 @@ class RevocationServiceTest {
     when(credentialMetadataRepository.findByCredentialTypeAndTisId(any(), any())).thenReturn(
         Optional.of(new CredentialMetadata()));
 
-    boolean revoked = service.revokeIfStale(TIS_ID, credentialType, baseline);
+    boolean revoked = service.revokeIfStale(CREDENTIAL_ID, TIS_ID, credentialType, baseline);
 
     assertThat("Unexpected revoked flag.", revoked, is(true));
     verify(gatewayService).revokeCredential(any(), any());
@@ -164,7 +164,7 @@ class RevocationServiceTest {
     ModificationMetadata metadata = new ModificationMetadata(null, modified);
     when(repository.findById(any())).thenReturn(Optional.of(metadata));
 
-    boolean revoked = service.revokeIfStale(TIS_ID, credentialType, baseline);
+    boolean revoked = service.revokeIfStale(CREDENTIAL_ID, TIS_ID, credentialType, baseline);
 
     assertThat("Unexpected revoked flag.", revoked, is(false));
     verifyNoInteractions(gatewayService);
@@ -179,7 +179,7 @@ class RevocationServiceTest {
     ModificationMetadata metadata = new ModificationMetadata(null, baseline);
     when(repository.findById(any())).thenReturn(Optional.of(metadata));
 
-    boolean revoked = service.revokeIfStale(TIS_ID, credentialType, baseline);
+    boolean revoked = service.revokeIfStale(CREDENTIAL_ID, TIS_ID, credentialType, baseline);
 
     assertThat("Unexpected revoked flag.", revoked, is(false));
     verifyNoInteractions(gatewayService);
@@ -193,7 +193,7 @@ class RevocationServiceTest {
 
     when(repository.findById(any())).thenReturn(Optional.empty());
 
-    boolean revoked = service.revokeIfStale(TIS_ID, credentialType, baseline);
+    boolean revoked = service.revokeIfStale(CREDENTIAL_ID, TIS_ID, credentialType, baseline);
 
     assertThat("Unexpected revoked flag.", revoked, is(false));
     verifyNoInteractions(gatewayService);


### PR DESCRIPTION
During start of issuance a timestamp should be recorded, which can be retrieved during the issuance completion step.
The timestamp will be compared against the last modification time to ensure that the data wasn't changed while the user was interacting with the gateway (which has a lengthy time out).

TIS21-4147