### PR TITLE
fix: use current time for modified timestamp

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.12.0"
+version = "0.12.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/DeleteEventDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/DeleteEventDto.java
@@ -23,15 +23,12 @@ package uk.nhs.hee.tis.trainee.credentials.dto;
 
 import jakarta.validation.constraints.NotEmpty;
 import java.io.Serializable;
-import java.time.Instant;
 
 /**
  * A DTO representing data deletion events.
  *
- * @param tisId     The id of the record.
- * @param timestamp The timestamp of the deletion.
+ * @param tisId The id of the record.
  */
-public record DeleteEventDto(
-    @NotEmpty String tisId, Instant timestamp) implements Serializable {
+public record DeleteEventDto(@NotEmpty String tisId) implements Serializable {
 
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/event/PlacementEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/event/PlacementEventListener.java
@@ -51,7 +51,6 @@ public class PlacementEventListener {
   @SqsListener(value = "${application.aws.sqs.delete-placement}", deletionPolicy = ON_SUCCESS)
   void deletePlacement(DeleteEventDto deletedPlacement) {
     log.info("Received delete event for placement {}.", deletedPlacement);
-    revocationService.revoke(deletedPlacement.tisId(), CredentialType.TRAINING_PLACEMENT,
-        deletedPlacement.timestamp());
+    revocationService.revoke(deletedPlacement.tisId(), CredentialType.TRAINING_PLACEMENT);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/event/ProgrammeMembershipEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/event/ProgrammeMembershipEventListener.java
@@ -52,7 +52,6 @@ public class ProgrammeMembershipEventListener {
       deletionPolicy = ON_SUCCESS)
   void deleteProgrammeMembership(DeleteEventDto deletedProgrammeMembership) {
     log.info("Received delete event for programme membership {}.", deletedProgrammeMembership);
-    revocationService.revoke(deletedProgrammeMembership.tisId(), CredentialType.TRAINING_PROGRAMME,
-        deletedProgrammeMembership.timestamp());
+    revocationService.revoke(deletedProgrammeMembership.tisId(), CredentialType.TRAINING_PROGRAMME);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/event/PlacementEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/event/PlacementEventListenerTest.java
@@ -21,13 +21,10 @@
 
 package uk.nhs.hee.tis.trainee.credentials.event;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import java.time.Duration;
-import java.time.Instant;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,29 +47,10 @@ class PlacementEventListenerTest {
 
   @Test
   void shouldDeletePlacement() {
-    DeleteEventDto dto = new DeleteEventDto(TIS_ID, null);
+    DeleteEventDto dto = new DeleteEventDto(TIS_ID);
 
     listener.deletePlacement(dto);
 
-    verify(service).revoke(eq(TIS_ID), eq(CredentialType.TRAINING_PLACEMENT), any());
-  }
-
-  @Test
-  void shouldPassNullTimestampWhenDeletingPlacementWithNoTimestamp() {
-    DeleteEventDto dto = new DeleteEventDto(TIS_ID, null);
-
-    listener.deletePlacement(dto);
-
-    verify(service).revoke(TIS_ID, CredentialType.TRAINING_PLACEMENT, null);
-  }
-
-  @Test
-  void shouldPassProvidedTimestampWhenDeletingPlacementWithTimestamp() {
-    Instant now = Instant.now().minus(Duration.ofDays(1));
-    DeleteEventDto dto = new DeleteEventDto(TIS_ID, now);
-
-    listener.deletePlacement(dto);
-
-    verify(service).revoke(TIS_ID, CredentialType.TRAINING_PLACEMENT, now);
+    verify(service).revoke(TIS_ID, CredentialType.TRAINING_PLACEMENT);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/event/ProgrammeMembershipEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/event/ProgrammeMembershipEventListenerTest.java
@@ -21,13 +21,10 @@
 
 package uk.nhs.hee.tis.trainee.credentials.event;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import java.time.Duration;
-import java.time.Instant;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,29 +47,10 @@ class ProgrammeMembershipEventListenerTest {
 
   @Test
   void shouldDeleteProgrammeMembership() {
-    DeleteEventDto dto = new DeleteEventDto(TIS_ID, null);
+    DeleteEventDto dto = new DeleteEventDto(TIS_ID);
 
     listener.deleteProgrammeMembership(dto);
 
-    verify(service).revoke(eq(TIS_ID), eq(CredentialType.TRAINING_PROGRAMME), any());
-  }
-
-  @Test
-  void shouldPassNullTimestampWhenDeletingProgrammeMembershipWithNoTimestamp() {
-    DeleteEventDto dto = new DeleteEventDto(TIS_ID, null);
-
-    listener.deleteProgrammeMembership(dto);
-
-    verify(service).revoke(TIS_ID, CredentialType.TRAINING_PROGRAMME, null);
-  }
-
-  @Test
-  void shouldPassProvidedTimestampWhenDeletingProgrammeMembershipWithTimestamp() {
-    Instant now = Instant.now().minus(Duration.ofDays(1));
-    DeleteEventDto dto = new DeleteEventDto(TIS_ID, now);
-
-    listener.deleteProgrammeMembership(dto);
-
-    verify(service).revoke(TIS_ID, CredentialType.TRAINING_PROGRAMME, now);
+    verify(service).revoke(TIS_ID, CredentialType.TRAINING_PROGRAMME);
   }
 }


### PR DESCRIPTION
The last modification timestamp uses the timestamp from the update message if it is available, however that can lead to incorrect behaviour depending on the delay between the update/delete occuring at source and it being received by this service.

Example theoretical timeline:
 - 00:00 - record created in TIS
 - 00:10 - record received by credentials service, last modified date stored
 - 00:20 - record deleted in TIS and added to queues
 - 00:30 - user starts issuance process, start time recorded as `00:30`
 - 00:40 - delete event received by credentials service, last modified recorded, from source, as `00:20`
 - 00:50 - user completes issuance service, callback compares the issuance start time `00:30` against the last modified time `00:20` and determines that the data was not stale.

By changing the last modified to always be the current time, the last modified would be `00:40`. Which when compared to the issuance start time `00:30` would flag the data as stale correctly.

TIS21-4147
TIS21-4347