### PR TITLE
fix: revert spring dependency updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id "java"
-  id "org.springframework.boot" version "3.0.5"
+  id "org.springframework.boot" version "3.0.4"
   id "io.spring.dependency-management" version "1.1.0"
 
   // Code quality plugins
@@ -47,7 +47,7 @@ dependencies {
   implementation "io.sentry:sentry-logback:$sentryVersion"
 
   // Amazon SQS
-  implementation "org.springframework:spring-messaging:6.0.7"
+  implementation "org.springframework:spring-messaging:5.3.25"
   implementation "io.awspring.cloud:spring-cloud-starter-aws"
   implementation "io.awspring.cloud:spring-cloud-aws-messaging"
 


### PR DESCRIPTION
Revert "Merge pull request #45 from Health-Education-England/dependabot/gradle/org.springframework-spring-messaging-6.0.7"

This reverts commit d168dd178300439135f6155a10a63e582a529da0, reversing changes made to 50736c0eb1dfbb71a1cbc92a923472d045d4ba40.

Revert "Merge pull request #46 from Health-Education-England/dependabot/gradle/org.springframework.boot-3.0.5"

This reverts commit 50736c0eb1dfbb71a1cbc92a923472d045d4ba40, reversing changes made to e8c59c109b926a1ad24dbe66485cd316bb134172.

TIS21-SHED