### PR TITLE
fix: gateway issuer audience

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.14.1"
+version = "0.14.2"
 
 configurations {
   compileOnly {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,7 +27,7 @@ application:
       authorize-endpoint: ${application.gateway.host}/oidc/authorize?client_id=${application.gateway.client-id}
       token-endpoint: ${application.gateway.host}/oidc/token
       token:
-        audience: ${application.gateway.host}/issuing
+        audience: ${application.gateway.host}/oidc
         issuer: ${application.gateway.client-id}
         signing-key: ${GATEWAY_TOKEN_SIGNING_KEY}
       redirect-uri: ${GATEWAY_ISSUING_REDIRECT_URI}


### PR DESCRIPTION
The gateway endpoints have been changed, as a result the `aud` used in the tokens must be changed too.

TIS21-4545