### PR TITLE
Revert "chore(deps): bump sentryVersion from 6.19.1 to 6.20.0"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
   testAnnotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
 
   // Sentry reporting
-  ext.sentryVersion = "6.20.0"
+  ext.sentryVersion = "6.19.1"
   implementation "io.sentry:sentry-spring-boot-starter:$sentryVersion"
   implementation "io.sentry:sentry-logback:$sentryVersion"
 


### PR DESCRIPTION
Reverts Health-Education-England/tis-trainee-credentials#73

We'll need to investigate a fix for this, but probably better just to revert for now.