### PR TITLE
fix: make identity verification case insensitive

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.14.2"
+version = "0.14.3"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationService.java
@@ -204,8 +204,8 @@ public class VerificationService {
       String claimFamilyName = claims.get(CLAIM_FAMILY_NAME, String.class);
       LocalDate claimBirthDate = LocalDate.parse(claims.get(CLAIM_BIRTH_DATE, String.class));
 
-      if (identityData.forenames().equals(claimFirstName) && identityData.surname()
-          .equals(claimFamilyName) && identityData.dateOfBirth().equals(claimBirthDate)) {
+      if (identityData.forenames().equalsIgnoreCase(claimFirstName) && identityData.surname()
+          .equalsIgnoreCase(claimFamilyName) && identityData.dateOfBirth().equals(claimBirthDate)) {
         Optional<String> sessionIdentifier = cachingDelegate.getUnverifiedSessionIdentifier(nonce);
 
         // If the unverified session is cached, move it to the verified session cache.


### PR DESCRIPTION
The identity verification is currently case sensitive, the identity credentials being used for UAT are all upper case. Relax our verification to accept any casing for the identity credential.

This may need reviewing later, but it seems a safe enough change to make.

TIS21-SHED