### PR TITLE
fix: disable XRay tracing on revocation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.17.0"
+version = "0.17.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationService.java
@@ -21,12 +21,10 @@
 
 package uk.nhs.hee.tis.trainee.credentials.service;
 
-import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.trainee.credentials.dto.CredentialType;
 import uk.nhs.hee.tis.trainee.credentials.model.CredentialMetadata;
@@ -40,7 +38,6 @@ import uk.nhs.hee.tis.trainee.credentials.repository.ModificationMetadataReposit
  */
 @Slf4j
 @Service
-@XRayEnabled
 public class RevocationService {
 
   private final CredentialMetadataRepository credentialMetadataRepository;


### PR DESCRIPTION
Revocation is done via event, rather than API call. Currently the SQS messages do not include suitable data to allow full tracing, a later piece of work will look at how we can support XRay across our event based workflows.

TIS21-4226