### PR TITLE
feat: record revoked credentials

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.17.1"
+version = "0.18.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/model/CredentialMetadata.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/model/CredentialMetadata.java
@@ -47,5 +47,6 @@ public class CredentialMetadata implements Serializable {
   private String credentialType;
   private String tisId;
   private Instant issuedAt;
+  private Instant revokedAt;
   private Instant expiresAt;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationService.java
@@ -90,7 +90,9 @@ public class RevocationService {
       credentialMetadataList.forEach(metadata -> {
         gatewayService.revokeCredential(credentialType.getTemplateName(),
             metadata.getCredentialId());
-        credentialMetadataRepository.deleteById(metadata.getCredentialId());
+
+        metadata.setRevokedAt(Instant.now());
+        credentialMetadataRepository.save(metadata);
         log.info("Credential {} for TIS ID {} has been revoked.", credentialType, tisId);
       });
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/IssuanceServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/IssuanceServiceTest.java
@@ -25,7 +25,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -377,12 +376,18 @@ class IssuanceServiceTest {
 
     ArgumentCaptor<CredentialMetadata> argument = ArgumentCaptor.forClass(CredentialMetadata.class);
     verify(credentialMetadataRepository).save(argument.capture());
-    assertEquals(CREDENTIAL_ID, argument.getValue().getCredentialId());
-    assertEquals(credentialData.getScope(), argument.getValue().getCredentialType());
-    assertEquals(TIS_ID, argument.getValue().getTisId());
-    assertEquals(TRAINEE_ID, argument.getValue().getTraineeId());
-    assertEquals(ISSUED_AT, argument.getValue().getIssuedAt());
-    assertEquals(EXPIRES_AT, argument.getValue().getExpiresAt());
+
+    CredentialMetadata credentialMetadata = argument.getValue();
+    assertThat("Unexpected credential ID.", credentialMetadata.getCredentialId(),
+        is(CREDENTIAL_ID));
+    assertThat("Unexpected credential type.", credentialMetadata.getCredentialType(),
+        is(credentialData.getScope()));
+    assertThat("Unexpected TIS ID.", credentialMetadata.getTisId(), is(TIS_ID));
+    assertThat("Unexpected trainee ID.", credentialMetadata.getTraineeId(), is(TRAINEE_ID));
+
+    assertThat("Unexpected issued at.", credentialMetadata.getIssuedAt(), is(ISSUED_AT));
+    assertThat("Unexpected expires at.", credentialMetadata.getExpiresAt(), is(EXPIRES_AT));
+    assertThat("Unexpected revoked at.", credentialMetadata.getRevokedAt(), nullValue());
   }
 
   @Test


### PR DESCRIPTION
When a credential is revoked the held metadata for that credential is deleted. Instead the metadata should be updated with a timestamp for when the revocation occured.

TIS21-5132
TIS21-5112