### PR TITLE
chore: move healthcheck to sidecar

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -3,12 +3,6 @@
     {
       "name": "tis-trainee-credentials",
       "image": "430723991443.dkr.ecr.eu-west-2.amazonaws.com/tis-trainee-credentials:latest",
-      "healthcheck": {
-        "command": [
-          "CMD-SHELL",
-          "curl -f http://localhost:8210/credentials/actuator/health || exit 1"
-        ]
-      },
       "secrets": [
         {
           "name": "AWS_XRAY_DAEMON_ADDRESS",
@@ -130,6 +124,20 @@
           "value": "${environment}"
         }
       ]
+    },
+    {
+      "name": "healthchecker",
+      "image": "alpine/curl:latest",
+      "healthCheck": {
+        "command": [
+          "CMD-SHELL",
+          "curl -f http://localhost:8210/credentials/actuator/health || exit 1"
+        ],
+        "interval": 30,
+        "timeout": 20,
+        "retries": 3,
+        "startPeriod": 300
+      }
     }
   ],
   "family": "tis-trainee-credentials-${environment}",


### PR DESCRIPTION
The Spring Boot built image does not contain curl, add a sidecar instance of `alpine/curl` to perform the healthcheck endpoint calls.

TIS21-SHED