### PR TITLE
chore: keep health check sidecar running

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -3,6 +3,12 @@
     {
       "name": "tis-trainee-credentials",
       "image": "430723991443.dkr.ecr.eu-west-2.amazonaws.com/tis-trainee-credentials:latest",
+      "healthCheck": {
+        "command": [
+          "CMD-SHELL",
+          "exit 0"
+        ]
+      },
       "secrets": [
         {
           "name": "AWS_XRAY_DAEMON_ADDRESS",
@@ -126,17 +132,18 @@
       ]
     },
     {
-      "name": "healthchecker",
+      "name": "health-check-proxy",
       "image": "alpine/curl:latest",
+      "command": [
+        "sleep",
+        "infinity"
+      ],
       "healthCheck": {
         "command": [
           "CMD-SHELL",
           "curl -f http://localhost:8210/credentials/actuator/health || exit 1"
         ],
-        "interval": 30,
-        "timeout": 20,
-        "retries": 3,
-        "startPeriod": 300
+        "startPeriod": 120
       }
     }
   ],


### PR DESCRIPTION
Use a sleep command to keep the health check sidecar container running. Add an always Healthy healthcheck to the app container to allow overall task to be healthy.
Reduce the healthcheck start period to 120s, combined with 3 attempts at 30 second intervals that gives 4.5 minutes for the task to become healthy.

TIS21-SHED