### PR TITLE
fix: only revoke active credentials

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.18.0"
+version = "0.18.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationService.java
@@ -81,13 +81,17 @@ public class RevocationService {
     log.debug("Stored last modified time {} for {} {}.", timestamp, credentialType, tisId);
 
     // Find this credential in the credential metadata repository. If it exists, then revoke it.
-    List<CredentialMetadata> credentialMetadataList =
+    List<CredentialMetadata> credentialsMetadata =
         credentialMetadataRepository.findByCredentialTypeAndTisId(
             credentialType.getIssuanceScope(), tisId);
-    if (!credentialMetadataList.isEmpty()) {
+    List<CredentialMetadata> validCredentialsMetadata = credentialsMetadata.stream()
+        .filter(meta -> meta.getRevokedAt() == null)
+        .toList();
+
+    if (!validCredentialsMetadata.isEmpty()) {
       log.info("{} Issued credential(s) of type {} found for TIS ID {}, revoking.",
-          credentialMetadataList.size(), credentialType, tisId);
-      credentialMetadataList.forEach(metadata -> {
+          validCredentialsMetadata.size(), credentialType, tisId);
+      validCredentialsMetadata.forEach(metadata -> {
         gatewayService.revokeCredential(credentialType.getTemplateName(),
             metadata.getCredentialId());
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationServiceTest.java
@@ -105,6 +105,23 @@ class RevocationServiceTest {
 
   @ParameterizedTest
   @EnumSource(CredentialType.class)
+  void shouldNotAttemptRevocationWhenCredentialAlreadyRevoked(CredentialType credentialType) {
+    CredentialMetadata credentialMetadata = new CredentialMetadata();
+    credentialMetadata.setTisId(TIS_ID);
+    credentialMetadata.setCredentialId(CREDENTIAL_ID);
+    credentialMetadata.setRevokedAt(Instant.now());
+
+    when(
+        credentialMetadataRepository.findByCredentialTypeAndTisId(credentialType.getIssuanceScope(),
+            TIS_ID)).thenReturn(List.of(credentialMetadata));
+
+    service.revoke(TIS_ID, credentialType);
+
+    verifyNoInteractions(gatewayService);
+  }
+
+  @ParameterizedTest
+  @EnumSource(CredentialType.class)
   void shouldNotUpdateCredentialMetadataWhenRevocationFails(CredentialType credentialType) {
     CredentialMetadata credentialMetadata = new CredentialMetadata();
     credentialMetadata.setTisId(TIS_ID);


### PR DESCRIPTION
Currently the revocation service will attempt to revoke a credential that has already been revoked.
Add a filter to ensure that revoked credentials are not attempted to be revoked again.

TIS21-5132
TIS21-5112