### PR TITLE
feat: emit cred event after revocation

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -87,6 +87,10 @@
           "valueFrom": "/tis/trainee/${environment}/redis/password"
         },
         {
+          "name": "REVOKE_TOPIC_ARN",
+          "valueFrom": "/tis/trainee/${environment}/topic-arn/credential-event"
+        },
+        {
           "name": "DELETE_PLACEMENT_QUEUE_URL",
           "valueFrom": "/tis/trainee/sync/${environment}/queue-url/delete-placement"
         },

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.18.2"
+version = "0.19.0"
 
 configurations {
   compileOnly {
@@ -54,6 +54,7 @@ dependencies {
   implementation "io.sentry:sentry-logback:$sentryVersion"
 
   // Amazon SQS
+  implementation "io.awspring.cloud:spring-cloud-aws-starter-sns"
   implementation "io.awspring.cloud:spring-cloud-aws-starter-sqs"
 
   //AWS X-ray

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/CredentialEventDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/CredentialEventDto.java
@@ -19,18 +19,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.trainee.credentials;
+package uk.nhs.hee.tis.trainee.credentials.dto;
 
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
+import java.util.UUID;
 
-@SpringBootTest
-@ActiveProfiles("test")
-class TisTraineeCredentialsApplicationTest {
+/**
+ * A credential event.
+ *
+ * @param credentialId   The identifier of the credential.
+ * @param credentialType The credential type's display name.
+ * @param traineeId      The trainee who the credential was issued to.
+ */
+public record CredentialEventDto(UUID credentialId, String credentialType, String traineeId) {
 
-  @Test
-  void contextLoads() {
-
-  }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/CredentialType.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/CredentialType.java
@@ -31,21 +31,24 @@ import lombok.Getter;
 @Getter
 public enum CredentialType {
 
-  TRAINING_PLACEMENT("TrainingPlacement", "/api/issue/placement"),
-  TRAINING_PROGRAMME("TrainingProgramme", "/api/issue/programme-membership");
+  TRAINING_PLACEMENT("Training Placement", "TrainingPlacement", "/api/issue/placement"),
+  TRAINING_PROGRAMME("Training Programme", "TrainingProgramme", "/api/issue/programme-membership");
 
   private static final String ISSUANCE_SCOPE_PREFIX = "issue.";
 
+  private final String displayName;
   private final String templateName;
   private final String apiPath;
 
   /**
    * Construct a credential type.
    *
+   * @param displayName  The name displayed to users.
    * @param templateName The gateway credential template name.
    * @param apiPath      The API request path for the credential type.
    */
-  CredentialType(String templateName, String apiPath) {
+  CredentialType(String displayName, String templateName, String apiPath) {
+    this.displayName = displayName;
     this.templateName = templateName;
     this.apiPath = apiPath;
   }
@@ -59,6 +62,20 @@ public enum CredentialType {
   public static Optional<CredentialType> fromPath(String apiPath) {
     return Arrays.stream(CredentialType.values())
         .filter(ct -> ct.apiPath.equals(apiPath))
+        .findFirst();
+  }
+
+  /**
+   * Get the credential type matching the given issuance scope.
+   *
+   * @param issuanceScope The issuance scope to match.
+   * @return The matched credential type, or else empty.
+   */
+  public static Optional<CredentialType> fromIssuanceScope(String issuanceScope) {
+    String templateName = issuanceScope.replaceFirst(ISSUANCE_SCOPE_PREFIX, "");
+
+    return Arrays.stream(CredentialType.values())
+        .filter(ct -> ct.templateName.equals(templateName))
         .findFirst();
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/mapper/CredentialEventMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/mapper/CredentialEventMapper.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.mapper;
+
+import java.util.Optional;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants.ComponentModel;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialEventDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialType;
+import uk.nhs.hee.tis.trainee.credentials.model.CredentialMetadata;
+
+/**
+ * A mapper to map to credential events.
+ */
+@Mapper(componentModel = ComponentModel.SPRING)
+public interface CredentialEventMapper {
+
+  /**
+   * Map metadata to a credential event.
+   *
+   * @param metadata The metadata to map.
+   * @return The mapped credential event.
+   */
+  @Mapping(target = "credentialType", source = "metadata")
+  CredentialEventDto toCredentialEvent(CredentialMetadata metadata);
+
+  /**
+   * Get the credential type of the given credential metadata.
+   *
+   * @param metadata The credential metadata to get the type of.
+   * @return The credential type if matched, or else null.
+   */
+  default String getTypeDisplayName(CredentialMetadata metadata) {
+    Optional<CredentialType> credentialType = CredentialType.fromIssuanceScope(
+        metadata.getCredentialType());
+    return credentialType.map(CredentialType::getDisplayName).orElse(null);
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/EventPublishingService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/EventPublishingService.java
@@ -1,0 +1,75 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.service;
+
+import io.awspring.cloud.sns.core.SnsNotification;
+import io.awspring.cloud.sns.core.SnsTemplate;
+import java.net.URI;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialEventDto;
+import uk.nhs.hee.tis.trainee.credentials.mapper.CredentialEventMapper;
+import uk.nhs.hee.tis.trainee.credentials.model.CredentialMetadata;
+
+/**
+ * A service handling publishing of events to an external message system.
+ */
+@Service
+public class EventPublishingService {
+
+  private static final String ROUTING_KEY = "event_type";
+  private static final String ROUTING_REVOCATION = "CREDENTIAL_REVOKED";
+
+  private final SnsTemplate snsTemplate;
+  private final URI topicArn;
+  private final CredentialEventMapper mapper;
+
+  /**
+   * A service handling publishing of events to an Amazon SNS.
+   *
+   * @param snsTemplate        The SNS template to publish with.
+   * @param revocationTopicArn The topic ARN to publish revocation events to.
+   * @param mapper             A mapper to allow creation of events from other data types.
+   */
+  public EventPublishingService(SnsTemplate snsTemplate,
+      @Value("${application.aws.sns.revocation-topic}") URI revocationTopicArn,
+      CredentialEventMapper mapper) {
+    this.snsTemplate = snsTemplate;
+    this.topicArn = revocationTopicArn;
+    this.mapper = mapper;
+  }
+
+  /**
+   * Publish a revocation event.
+   *
+   * @param credentialMetadata The metadata of the credential that was revoked.
+   */
+  public void publishRevocationEvent(CredentialMetadata credentialMetadata) {
+    CredentialEventDto credentialEvent = mapper.toCredentialEvent(credentialMetadata);
+
+    SnsNotification<CredentialEventDto> message = SnsNotification.builder(credentialEvent)
+        .groupId(credentialMetadata.getCredentialId())
+        .header(ROUTING_KEY, ROUTING_REVOCATION)
+        .build();
+    snsTemplate.sendNotification(topicArn.toString(), message);
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/RevocationService.java
@@ -44,13 +44,15 @@ public class RevocationService {
 
   private final ModificationMetadataRepository modificationMetadataRepository;
   private final GatewayService gatewayService;
+  private final EventPublishingService eventPublishingService;
 
   RevocationService(CredentialMetadataRepository credentialMetadataRepository,
       ModificationMetadataRepository modificationMetadataRepository,
-      GatewayService gatewayService) {
+      GatewayService gatewayService, EventPublishingService eventPublishingService) {
     this.credentialMetadataRepository = credentialMetadataRepository;
     this.modificationMetadataRepository = modificationMetadataRepository;
     this.gatewayService = gatewayService;
+    this.eventPublishingService = eventPublishingService;
   }
 
   /**
@@ -97,6 +99,7 @@ public class RevocationService {
 
         metadata.setRevokedAt(Instant.now());
         credentialMetadataRepository.save(metadata);
+        eventPublishingService.publishRevocationEvent(metadata);
         log.info("Credential {} for TIS ID {} has been revoked.", credentialType, tisId);
       });
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,8 @@ server:
 
 application:
   aws:
+    sns:
+      revocation-topic: ${REVOKE_TOPIC_ARN:}
     sqs:
       delete-placement: ${DELETE_PLACEMENT_QUEUE_URL:}
       delete-programme-membership: ${DELETE_PROGRAMME_MEMBERSHIP_QUEUE_URL:}

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/EventPublishingServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/EventPublishingServiceTest.java
@@ -1,0 +1,140 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.awspring.cloud.sns.core.SnsNotification;
+import io.awspring.cloud.sns.core.SnsTemplate;
+import java.net.URI;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialEventDto;
+import uk.nhs.hee.tis.trainee.credentials.dto.CredentialType;
+import uk.nhs.hee.tis.trainee.credentials.mapper.CredentialEventMapperImpl;
+import uk.nhs.hee.tis.trainee.credentials.model.CredentialMetadata;
+
+class EventPublishingServiceTest {
+
+  private static final URI REVOCATION_TOPIC_ARN = URI.create("arn:sns:test");
+
+  private static final UUID CREDENTIAL_ID = UUID.randomUUID();
+  private static final String TRAINEE_ID = "traineeId";
+  private static final String TIS_ID = "tisId";
+
+  private EventPublishingService service;
+  private SnsTemplate snsTemplate;
+
+  @BeforeEach
+  void setUp() {
+    snsTemplate = mock(SnsTemplate.class);
+    service = new EventPublishingService(snsTemplate, REVOCATION_TOPIC_ARN,
+        new CredentialEventMapperImpl());
+  }
+
+  @ParameterizedTest
+  @EnumSource(CredentialType.class)
+  void shouldSendToRevocationTopicWhenPublishingRevocationEvent(CredentialType credentialType) {
+    CredentialMetadata metadata = new CredentialMetadata();
+    metadata.setCredentialId(CREDENTIAL_ID.toString());
+    metadata.setCredentialType(credentialType.getIssuanceScope());
+    metadata.setTisId(TIS_ID);
+    metadata.setTraineeId(TRAINEE_ID);
+
+    service.publishRevocationEvent(metadata);
+
+    verify(snsTemplate).sendNotification(eq(REVOCATION_TOPIC_ARN.toString()),
+        any(SnsNotification.class));
+  }
+
+  @ParameterizedTest
+  @EnumSource(CredentialType.class)
+  void shouldSetGroupIdWhenPublishingRevocationEvent(CredentialType credentialType) {
+    CredentialMetadata metadata = new CredentialMetadata();
+    metadata.setCredentialId(CREDENTIAL_ID.toString());
+    metadata.setCredentialType(credentialType.getIssuanceScope());
+    metadata.setTisId(TIS_ID);
+    metadata.setTraineeId(TRAINEE_ID);
+
+    service.publishRevocationEvent(metadata);
+
+    ArgumentCaptor<SnsNotification<CredentialEventDto>> messageCaptor = ArgumentCaptor.forClass(
+        SnsNotification.class);
+    verify(snsTemplate).sendNotification(any(), messageCaptor.capture());
+
+    SnsNotification<CredentialEventDto> message = messageCaptor.getValue();
+    assertThat("Unexpected group ID.", message.getGroupId(), is(CREDENTIAL_ID.toString()));
+  }
+
+  @ParameterizedTest
+  @EnumSource(CredentialType.class)
+  void shouldSetRoutingKeyWhenPublishingRevocationEvent(CredentialType credentialType) {
+    CredentialMetadata metadata = new CredentialMetadata();
+    metadata.setCredentialId(CREDENTIAL_ID.toString());
+    metadata.setCredentialType(credentialType.getIssuanceScope());
+    metadata.setTisId(TIS_ID);
+    metadata.setTraineeId(TRAINEE_ID);
+
+    service.publishRevocationEvent(metadata);
+
+    ArgumentCaptor<SnsNotification<CredentialEventDto>> messageCaptor = ArgumentCaptor.forClass(
+        SnsNotification.class);
+    verify(snsTemplate).sendNotification(any(), messageCaptor.capture());
+
+    SnsNotification<CredentialEventDto> message = messageCaptor.getValue();
+    Map<String, Object> headers = message.getHeaders();
+    Object eventType = headers.get("event_type");
+    assertThat("Unexpected event type.", eventType, is("CREDENTIAL_REVOKED"));
+  }
+
+  @ParameterizedTest
+  @EnumSource(CredentialType.class)
+  void shouldIncludePayloadWhenPublishingRevocationEvent(CredentialType credentialType) {
+    CredentialMetadata metadata = new CredentialMetadata();
+    metadata.setCredentialId(CREDENTIAL_ID.toString());
+    metadata.setCredentialType(credentialType.getIssuanceScope());
+    metadata.setTisId(TIS_ID);
+    metadata.setTraineeId(TRAINEE_ID);
+
+    service.publishRevocationEvent(metadata);
+
+    ArgumentCaptor<SnsNotification<CredentialEventDto>> messageCaptor = ArgumentCaptor.forClass(
+        SnsNotification.class);
+    verify(snsTemplate).sendNotification(any(), messageCaptor.capture());
+
+    SnsNotification<CredentialEventDto> message = messageCaptor.getValue();
+    CredentialEventDto payload = message.getPayload();
+    assertThat("Unexpected credential id.", payload.credentialId(), is(CREDENTIAL_ID));
+    assertThat("Unexpected credential type.", payload.credentialType(),
+        is(credentialType.getDisplayName()));
+    assertThat("Unexpected trainee id.", payload.traineeId(), is(TRAINEE_ID));
+  }
+}


### PR DESCRIPTION
When a credential is revoked a credential event should be published to allow other services, such as notifications, to act accordingly.

Create an EventPublishingService to handle to publish to SNS, the group ID should be set to the credential's ID to allow better de-duplication and ensure that we cannot ever get multiple downstream instances processing events for the same credential simultaneously.

TIS21-5115
TIS21-5133