### PR TITLE
fix: PAR request missing required params

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.19.0"
+version = "0.19.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayService.java
@@ -64,6 +64,8 @@ public class GatewayService {
   private static final String NONCE = "nonce";
   private static final String ORGANIZATION_ID = "OrganisationId";
   private static final String REDIRECT_URI = "redirect_uri";
+  private static final String RESPONSE_MODE = "response_mode";
+  private static final String RESPONSE_TYPE = "response_type";
   private static final String REVOCATION_REASON = "RevocationReason";
   private static final String SCOPE = "scope";
   private static final String SERIAL_NUMBER = "SerialNumber";
@@ -123,6 +125,8 @@ public class GatewayService {
     bodyPair.add(REDIRECT_URI, properties.issuing().redirectUri());
     bodyPair.add(SCOPE, dto.getScope());
     bodyPair.add(ID_TOKEN_HINT, idTokenHint);
+    bodyPair.add(RESPONSE_TYPE, "code");
+    bodyPair.add(RESPONSE_MODE, "query");
     bodyPair.add(NONCE, nonce);
     bodyPair.add(STATE, state);
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/GatewayServiceTest.java
@@ -250,6 +250,36 @@ class GatewayServiceTest {
   }
 
   @Test
+  void shouldIncludeResponseTypeInParRequest() {
+    CredentialDto dto = mock(CredentialDto.class);
+
+    var argumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
+        eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
+
+    service.getCredentialUri(dto, NONCE, STATE);
+
+    var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
+    MultiValueMap<String, String> requestBody = request.getBody();
+    assertThat("Unexpected response type.", requestBody.get("response_type"), is(List.of("code")));
+  }
+
+  @Test
+  void shouldIncludeResponseModeInParRequest() {
+    CredentialDto dto = mock(CredentialDto.class);
+
+    var argumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+    when(restTemplate.postForEntity(eq(PAR_ENDPOINT), argumentCaptor.capture(),
+        eq(ParResponse.class))).thenReturn(ResponseEntity.ok(null));
+
+    service.getCredentialUri(dto, NONCE, STATE);
+
+    var request = (HttpEntity<MultiValueMap<String, String>>) argumentCaptor.getValue();
+    MultiValueMap<String, String> requestBody = request.getBody();
+    assertThat("Unexpected response mode.", requestBody.get("response_mode"), is(List.of("query")));
+  }
+
+  @Test
   void shouldIncludeStateInParRequest() {
     CredentialDto dto = mock(CredentialDto.class);
 


### PR DESCRIPTION
The PAR request previously defaulted the `response_type` and `response_mode` values, but they are now required parameters. The only valid values are the previous default of `code` and `query` respectively.

Update the PAR request to include the missing parameters.

TIS21-5232