### PR TITLE
feat: include issue/revoke timestamps in events

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.19.1"
+version = "0.20.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/CredentialEventDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/CredentialEventDto.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.tis.trainee.credentials.dto;
 
+import java.time.Instant;
 import java.util.UUID;
 
 /**
@@ -28,8 +29,11 @@ import java.util.UUID;
  *
  * @param credentialId   The identifier of the credential.
  * @param credentialType The credential type's display name.
+ * @param issuedAt       When the credential was issued.
+ * @param revokedAt      When the credential was revoked.
  * @param traineeId      The trainee who the credential was issued to.
  */
-public record CredentialEventDto(UUID credentialId, String credentialType, String traineeId) {
+public record CredentialEventDto(UUID credentialId, String credentialType, Instant issuedAt,
+                                 Instant revokedAt, String traineeId) {
 
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/EventPublishingService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/EventPublishingService.java
@@ -24,6 +24,7 @@ package uk.nhs.hee.tis.trainee.credentials.service;
 import io.awspring.cloud.sns.core.SnsNotification;
 import io.awspring.cloud.sns.core.SnsTemplate;
 import java.net.URI;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.trainee.credentials.dto.CredentialEventDto;
@@ -33,6 +34,7 @@ import uk.nhs.hee.tis.trainee.credentials.model.CredentialMetadata;
 /**
  * A service handling publishing of events to an external message system.
  */
+@Slf4j
 @Service
 public class EventPublishingService {
 
@@ -64,6 +66,8 @@ public class EventPublishingService {
    * @param credentialMetadata The metadata of the credential that was revoked.
    */
   public void publishRevocationEvent(CredentialMetadata credentialMetadata) {
+    String credentialId = credentialMetadata.getCredentialId();
+    log.info("Publishing revocation event for credential {}", credentialId);
     CredentialEventDto credentialEvent = mapper.toCredentialEvent(credentialMetadata);
 
     SnsNotification<CredentialEventDto> message = SnsNotification.builder(credentialEvent)
@@ -71,5 +75,6 @@ public class EventPublishingService {
         .header(ROUTING_KEY, ROUTING_REVOCATION)
         .build();
     snsTemplate.sendNotification(topicArn.toString(), message);
+    log.info("Published revocation event for credential {} to topic {}", credentialId, topicArn);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/EventPublishingServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/EventPublishingServiceTest.java
@@ -31,6 +31,8 @@ import static org.mockito.Mockito.verify;
 import io.awspring.cloud.sns.core.SnsNotification;
 import io.awspring.cloud.sns.core.SnsTemplate;
 import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,6 +51,9 @@ class EventPublishingServiceTest {
   private static final UUID CREDENTIAL_ID = UUID.randomUUID();
   private static final String TRAINEE_ID = "traineeId";
   private static final String TIS_ID = "tisId";
+
+  private static final Instant ISSUED_AT = Instant.now();
+  private static final Instant REVOKED_AT = Instant.now().plus(Duration.ofHours(1));
 
   private EventPublishingService service;
   private SnsTemplate snsTemplate;
@@ -123,6 +128,8 @@ class EventPublishingServiceTest {
     metadata.setCredentialType(credentialType.getIssuanceScope());
     metadata.setTisId(TIS_ID);
     metadata.setTraineeId(TRAINEE_ID);
+    metadata.setIssuedAt(ISSUED_AT);
+    metadata.setRevokedAt(REVOKED_AT);
 
     service.publishRevocationEvent(metadata);
 
@@ -136,5 +143,7 @@ class EventPublishingServiceTest {
     assertThat("Unexpected credential type.", payload.credentialType(),
         is(credentialType.getDisplayName()));
     assertThat("Unexpected trainee id.", payload.traineeId(), is(TRAINEE_ID));
+    assertThat("Unexpected issued at.", payload.issuedAt(), is(ISSUED_AT));
+    assertThat("Unexpected revoked at.", payload.revokedAt(), is(REVOKED_AT));
   }
 }


### PR DESCRIPTION
Include the `issuedAt` and `revokedAt` values when publishing credential events.

TIS21-5115