### PR TITLE
feat: remove expiresAt from credential metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.21.2"
+version = "0.22.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/IssueResponseDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/dto/IssueResponseDto.java
@@ -31,12 +31,10 @@ import java.time.Instant;
  * @param credentialId The ID of the credential.
  * @param traineeId    The user's TIS ID.
  * @param issuedAt     The date and time the credential was issued.
- * @param expiresAt    The date and time the credential expires.
  */
 public record IssueResponseDto(
     @NotEmpty String credentialId,
     @NotEmpty String traineeId,
-    @NotEmpty Instant issuedAt,
-    @NotEmpty Instant expiresAt) implements Serializable {
+    @NotEmpty Instant issuedAt) implements Serializable {
 
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/mapper/CredentialMetadataMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/mapper/CredentialMetadataMapper.java
@@ -49,7 +49,7 @@ public interface CredentialMetadataMapper {
   @Mapping(target = "credentialType", source = "credentialData.scope")
   @Mapping(target = "tisId", source = "credentialData.tisId")
   @Mapping(target = "issuedAt", source = "responseDto.issuedAt")
-  @Mapping(target = "expiresAt", source = "responseDto.expiresAt")
+  @Mapping(target = "revokedAt", ignore = true)
   CredentialMetadata toCredentialMetadata(String traineeId, CredentialDto credentialData,
       IssueResponseDto responseDto);
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/model/CredentialMetadata.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/model/CredentialMetadata.java
@@ -48,5 +48,4 @@ public class CredentialMetadata implements Serializable {
   private String tisId;
   private Instant issuedAt;
   private Instant revokedAt;
-  private Instant expiresAt;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/CredentialMetadataService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/CredentialMetadataService.java
@@ -27,7 +27,6 @@ import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.util.Comparator;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.trainee.credentials.dto.CredentialType;
@@ -81,6 +80,6 @@ public class CredentialMetadataService {
             .max(Comparator.comparing(CredentialMetadata::getIssuedAt))
             .orElseThrow(
                 () -> new NoSuchElementException("credentials getIssuedAt value not present")))
-        .collect(Collectors.toList());
+        .toList();
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/IssuanceService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/IssuanceService.java
@@ -186,9 +186,8 @@ public class IssuanceService {
   private IssueResponseDto fromIssuedResponse(Claims claims, String traineeTisId) {
     String credentialId = claims.get("SerialNumber", String.class);
     Instant issuedAt = Instant.ofEpochSecond(claims.get("iat", Long.class));
-    Instant expiresAt = Instant.ofEpochSecond(claims.get("exp", Long.class));
 
-    return new IssueResponseDto(credentialId, traineeTisId, issuedAt, expiresAt);
+    return new IssueResponseDto(credentialId, traineeTisId, issuedAt);
   }
 
   /**

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/IssuanceServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/IssuanceServiceTest.java
@@ -78,7 +78,6 @@ class IssuanceServiceTest {
   private static final String TRAINEE_ID = "the-trainee-id";
   private static final String CREDENTIAL_ID = "123-456-789";
   private static final Instant ISSUED_AT = Instant.MIN.truncatedTo(ChronoUnit.SECONDS);
-  private static final Instant EXPIRES_AT = Instant.MAX.truncatedTo(ChronoUnit.SECONDS);
 
   private static final String SESSION_ID_FIELD = "origin_jti";
   private static final String SESSION_ID_VALUE = UUID.randomUUID().toString();
@@ -365,7 +364,6 @@ class IssuanceServiceTest {
     claimsIssued.put("nonce", nonce.toString());
     claimsIssued.put("SerialNumber", CREDENTIAL_ID);
     claimsIssued.put("iat", ISSUED_AT.getEpochSecond());
-    claimsIssued.put("exp", EXPIRES_AT.getEpochSecond());
 
     when(gatewayService.getTokenClaims(eq(TOKEN_ENDPOINT), eq(REDIRECT_URI), eq(CODE_VALUE), any()))
         .thenReturn(claimsIssued);
@@ -386,7 +384,6 @@ class IssuanceServiceTest {
     assertThat("Unexpected trainee ID.", credentialMetadata.getTraineeId(), is(TRAINEE_ID));
 
     assertThat("Unexpected issued at.", credentialMetadata.getIssuedAt(), is(ISSUED_AT));
-    assertThat("Unexpected expires at.", credentialMetadata.getExpiresAt(), is(EXPIRES_AT));
     assertThat("Unexpected revoked at.", credentialMetadata.getRevokedAt(), nullValue());
   }
 
@@ -397,7 +394,6 @@ class IssuanceServiceTest {
     claimsIssued.put("nonce", nonce.toString());
     claimsIssued.put("SerialNumber", CREDENTIAL_ID);
     claimsIssued.put("iat", ISSUED_AT.getEpochSecond());
-    claimsIssued.put("exp", EXPIRES_AT.getEpochSecond());
 
     when(gatewayService.getTokenClaims(eq(TOKEN_ENDPOINT), eq(REDIRECT_URI), eq(CODE_VALUE), any()))
         .thenReturn(claimsIssued);
@@ -417,7 +413,6 @@ class IssuanceServiceTest {
     claimsIssued.put("nonce", nonce.toString());
     claimsIssued.put("SerialNumber", CREDENTIAL_ID);
     claimsIssued.put("iat", ISSUED_AT.getEpochSecond());
-    claimsIssued.put("exp", EXPIRES_AT.getEpochSecond());
 
     when(gatewayService.getTokenClaims(eq(TOKEN_ENDPOINT), eq(REDIRECT_URI), eq(CODE_VALUE), any()))
         .thenReturn(claimsIssued);
@@ -484,7 +479,6 @@ class IssuanceServiceTest {
     claimsIssued.put("nonce", UUID.randomUUID().toString());
     claimsIssued.put("SerialNumber", CREDENTIAL_ID);
     claimsIssued.put("iat", ISSUED_AT.getEpochSecond());
-    claimsIssued.put("exp", EXPIRES_AT.getEpochSecond());
 
     when(gatewayService.getTokenClaims(any(), any(), any(), any())).thenReturn(claimsIssued);
     when(cachingDelegate.getCredentialData(any())).thenReturn(Optional.of(credentialData));
@@ -512,7 +506,6 @@ class IssuanceServiceTest {
     claimsIssued.put("nonce", UUID.randomUUID().toString());
     claimsIssued.put("SerialNumber", CREDENTIAL_ID);
     claimsIssued.put("iat", ISSUED_AT.getEpochSecond());
-    claimsIssued.put("exp", EXPIRES_AT.getEpochSecond());
 
     when(gatewayService.getTokenClaims(any(), any(), any(), any())).thenReturn(claimsIssued);
     when(cachingDelegate.getCredentialData(any())).thenReturn(Optional.of(credentialData));
@@ -540,7 +533,6 @@ class IssuanceServiceTest {
     claimsIssued.put("nonce", UUID.randomUUID().toString());
     claimsIssued.put("SerialNumber", CREDENTIAL_ID);
     claimsIssued.put("iat", ISSUED_AT.getEpochSecond());
-    claimsIssued.put("exp", EXPIRES_AT.getEpochSecond());
 
     when(gatewayService.getTokenClaims(any(), any(), any(), any())).thenReturn(claimsIssued);
     when(cachingDelegate.getCredentialData(any())).thenReturn(Optional.of(credentialData));


### PR DESCRIPTION
The expiration record against the credential metadata is not the credential expiration and is instead the expiration of the token provided with the credential data.
The real expiration date is not currently available, so the `expiresAt` field should be removed to avoid confusion.

Some additional boy scouting of the `CredentialMetadataService` tests.

TIS21-5263
TIS21-5325