### PR TITLE
feat: handle verification callback errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.22.1"
+version = "0.23.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/VerifyResource.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/api/VerifyResource.java
@@ -68,10 +68,13 @@ public class VerifyResource {
   }
 
   @GetMapping("/callback")
-  ResponseEntity<String> handleVerification(@RequestParam String code,
-      @UUID @RequestParam String state) {
+  ResponseEntity<String> handleVerification(
+      @RequestParam String code,
+      @UUID @RequestParam String state,
+      @RequestParam(required = false) String error,
+      @RequestParam(required = false, value = "error_description") String errorDescription) {
     log.info("Received callback for credential verification.");
-    URI uri = service.completeCredentialVerification(code, state);
+    URI uri = service.completeCredentialVerification(code, state, error, errorDescription);
 
     log.info("Credential verification completed.");
     return ResponseEntity.status(HttpStatus.FOUND).location(uri).build();

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationServiceTest.java
@@ -253,13 +253,29 @@ class VerificationServiceTest {
     UUID state = UUID.randomUUID();
     when(cachingDelegate.getCodeVerifier(state)).thenReturn(Optional.empty());
 
-    URI uri = verificationService.completeCredentialVerification(CODE, state.toString());
+    URI uri = verificationService.completeCredentialVerification(CODE, state.toString(), null,
+        null);
 
     assertThat("Unexpected URI path.", uri.getPath(), is("/invalid-credential"));
 
     Map<String, String> queryParams = splitQueryParams(uri);
     String reason = queryParams.get(QUERY_PARAM_REASON);
     assertThat("Unexpected invalid reason.", reason, is("no_code_verifier"));
+  }
+
+  @Test
+  void shouldReturnInvalidCredentialWhenCallbackIncludesError() {
+    UUID state = UUID.randomUUID();
+    when(cachingDelegate.getCodeVerifier(state)).thenReturn(Optional.empty());
+
+    URI uri = verificationService.completeCredentialVerification(CODE, state.toString(),
+        "error_code", "Error description");
+
+    assertThat("Unexpected URI path.", uri.getPath(), is("/invalid-credential"));
+
+    Map<String, String> queryParams = splitQueryParams(uri);
+    String reason = queryParams.get(QUERY_PARAM_REASON);
+    assertThat("Unexpected invalid reason.", reason, is("Error description"));
   }
 
   @Test
@@ -273,7 +289,8 @@ class VerificationServiceTest {
     setDefaultClaimsMocks(new DefaultClaims(), nonce, codeVerifier);
     when(gatewayService.getTokenScope(any())).thenReturn("invalid-scope");
 
-    URI uri = verificationService.completeCredentialVerification(CODE, state.toString());
+    URI uri = verificationService.completeCredentialVerification(CODE, state.toString(), null,
+        null);
 
     assertThat("Unexpected URI path.", uri.getPath(), is("/invalid-credential"));
 
@@ -293,7 +310,8 @@ class VerificationServiceTest {
     setDefaultClaimsMocks(claims, nonce, codeVerifier);
     when(cachingDelegate.getIdentityData(nonce)).thenReturn(Optional.empty());
 
-    URI uri = verificationService.completeCredentialVerification(CODE, state.toString());
+    URI uri = verificationService.completeCredentialVerification(CODE, state.toString(), null,
+        null);
 
     assertThat("Unexpected URI path.", uri.getPath(), is("/invalid-credential"));
 
@@ -323,7 +341,8 @@ class VerificationServiceTest {
         IDENTITY_DOB);
     when(cachingDelegate.getIdentityData(nonce)).thenReturn(Optional.of(identityData));
 
-    URI uri = verificationService.completeCredentialVerification(CODE, state.toString());
+    URI uri = verificationService.completeCredentialVerification(CODE, state.toString(), null,
+        null);
 
     assertThat("Unexpected URI path.", uri.getPath(), is("/invalid-credential"));
 
@@ -353,7 +372,8 @@ class VerificationServiceTest {
         IDENTITY_DOB);
     when(cachingDelegate.getIdentityData(nonce)).thenReturn(Optional.of(identityData));
 
-    URI uri = verificationService.completeCredentialVerification(CODE, state.toString());
+    URI uri = verificationService.completeCredentialVerification(CODE, state.toString(), null,
+        null);
 
     assertThat("Unexpected URI path.", uri.getPath(), is("/invalid-credential"));
 
@@ -383,7 +403,8 @@ class VerificationServiceTest {
         IDENTITY_DOB);
     when(cachingDelegate.getIdentityData(nonce)).thenReturn(Optional.of(identityData));
 
-    URI uri = verificationService.completeCredentialVerification(CODE, state.toString());
+    URI uri = verificationService.completeCredentialVerification(CODE, state.toString(), null,
+        null);
 
     assertThat("Unexpected URI path.", uri.getPath(), is("/invalid-credential"));
 
@@ -412,7 +433,8 @@ class VerificationServiceTest {
         IDENTITY_DOB);
     when(cachingDelegate.getIdentityData(nonce)).thenReturn(Optional.of(identityData));
 
-    URI uri = verificationService.completeCredentialVerification(CODE, state.toString());
+    URI uri = verificationService.completeCredentialVerification(CODE, state.toString(), null,
+        null);
 
     assertThat("Unexpected URI path.", uri.getPath(), is("/invalid-credential"));
 
@@ -441,7 +463,8 @@ class VerificationServiceTest {
         IDENTITY_DOB);
     when(cachingDelegate.getIdentityData(nonce)).thenReturn(Optional.of(identityData));
 
-    URI uri = verificationService.completeCredentialVerification(CODE, state.toString());
+    URI uri = verificationService.completeCredentialVerification(CODE, state.toString(), null,
+        null);
 
     assertThat("Unexpected URI path.", uri.getPath(), is("/invalid-credential"));
 
@@ -477,7 +500,8 @@ class VerificationServiceTest {
         IDENTITY_DOB);
     when(cachingDelegate.getIdentityData(nonce)).thenReturn(Optional.of(identityData));
 
-    URI uri = verificationService.completeCredentialVerification(CODE, state.toString());
+    URI uri = verificationService.completeCredentialVerification(CODE, state.toString(), null,
+        null);
 
     assertThat("Unexpected URI path.", uri.getPath(), is("/credential-verified"));
   }
@@ -504,7 +528,7 @@ class VerificationServiceTest {
         IDENTITY_DOB);
     when(cachingDelegate.getIdentityData(nonce)).thenReturn(Optional.of(identityData));
 
-    verificationService.completeCredentialVerification(CODE, state.toString());
+    verificationService.completeCredentialVerification(CODE, state.toString(), null, null);
 
     verify(cachingDelegate).cacheVerifiedIdentityIdentifier("session123", identityId);
   }
@@ -515,7 +539,8 @@ class VerificationServiceTest {
     when(cachingDelegate.getCodeVerifier(state)).thenReturn(Optional.empty());
     when(cachingDelegate.getClientState(state)).thenReturn(Optional.of("client-state"));
 
-    URI uri = verificationService.completeCredentialVerification(CODE, state.toString());
+    URI uri = verificationService.completeCredentialVerification(CODE, state.toString(), null,
+        null);
 
     Map<String, String> queryParams = splitQueryParams(uri);
     String clientState = queryParams.get(QUERY_PARAM_STATE);
@@ -528,7 +553,8 @@ class VerificationServiceTest {
     when(cachingDelegate.getCodeVerifier(state)).thenReturn(Optional.empty());
     when(cachingDelegate.getClientState(state)).thenReturn(Optional.empty());
 
-    URI uri = verificationService.completeCredentialVerification(CODE, state.toString());
+    URI uri = verificationService.completeCredentialVerification(CODE, state.toString(), null,
+        null);
 
     Map<String, String> queryParams = splitQueryParams(uri);
     assertThat("Unexpected client state presence.", queryParams.keySet(),


### PR DESCRIPTION
Currently any error messages returned to the verification callback are ignored.
Update the verification endpoint and service to include the failure reason in the redirect URL, allowing the client to display the message instead of a generic error screen.

TIS21-4778
TIS21-5502