### PR TITLE
feat: add fuzzy name matching during id checks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.23.5"
+version = "0.24.0"
 
 configurations {
   compileOnly {
@@ -53,14 +53,14 @@ dependencies {
   implementation("io.sentry:sentry-spring-boot-starter-jakarta:$sentryVersion")
   implementation("io.sentry:sentry-logback:$sentryVersion")
 
-  // Amazon SQS
+  // AWS
   implementation("io.awspring.cloud:spring-cloud-aws-starter-sns")
   implementation("io.awspring.cloud:spring-cloud-aws-starter-sqs")
-
-  //AWS X-ray
+  implementation("io.micrometer:micrometer-registry-cloudwatch2")
   implementation("com.amazonaws:aws-xray-recorder-sdk-spring:2.15.2")
 
-  implementation("commons-codec:commons-codec:1.16.1")
+  implementation("commons-codec:commons-codec:1.17.1")
+  implementation("org.apache.commons:commons-text:1.12.0")
 
   val jjwtVersion = "0.11.5"
   implementation("io.jsonwebtoken:jjwt-api:$jjwtVersion")

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/MetricsConfiguration.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/MetricsConfiguration.java
@@ -33,15 +33,15 @@ import org.springframework.context.annotation.Configuration;
 public class MetricsConfiguration {
 
   /**
-   * A meter provider for the identity accuracy metrics.
+   * A meter provider for the identity inaccuracy metrics.
    *
    * @param registry The registry to use.
-   * @return The identity accuracy meter provider.
+   * @return The identity inaccuracy meter provider.
    */
   @Bean
-  MeterProvider<DistributionSummary> identityAccuracy(MeterRegistry registry) {
-    return DistributionSummary.builder("identity.accuracy")
-        .description("How closely matched a given identity's name was to TIS data.")
+  MeterProvider<DistributionSummary> identityInaccuracy(MeterRegistry registry) {
+    return DistributionSummary.builder("identity.inaccuracy")
+        .description("How different a given identity's name was to TIS data.")
         .baseUnit(BaseUnits.PERCENT)
         .scale(100)
         .maximumExpectedValue(100.0)

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/MetricsConfiguration.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/MetricsConfiguration.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.config;
+
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.BaseUnits;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Configuration of custom application metrics. */
+@Configuration
+public class MetricsConfiguration {
+
+  /**
+   * A distribution summary for the accuracy of text based identity verification.
+   *
+   * @param registry The meter registry to use.
+   * @return The build distribution summary.
+   */
+  @Bean
+  DistributionSummary identityTextAccuracy(MeterRegistry registry) {
+    return DistributionSummary.builder("identity.accuracy.text")
+        .description("How closely matched the text of a given identity was to TIS data.")
+        .baseUnit(BaseUnits.PERCENT)
+        .scale(100)
+        .maximumExpectedValue(100.0)
+        .register(registry);
+  }
+
+  /**
+   * A distribution summary for the accuracy of phonetic based identity verification.
+   *
+   * @param registry The meter registry to use.
+   * @return The build distribution summary.
+   */
+  @Bean
+  DistributionSummary identityPhoneticAccuracy(MeterRegistry registry) {
+    return DistributionSummary.builder("identity.accuracy.phonetic")
+        .description("How closely matched the phonetics of a given identity was to TIS data.")
+        .baseUnit(BaseUnits.PERCENT)
+        .scale(100)
+        .maximumExpectedValue(100.0)
+        .register(registry);
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/MetricsConfiguration.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/config/MetricsConfiguration.java
@@ -22,6 +22,7 @@
 package uk.nhs.hee.tis.trainee.credentials.config;
 
 import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Meter.MeterProvider;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.BaseUnits;
 import org.springframework.context.annotation.Bean;
@@ -32,34 +33,18 @@ import org.springframework.context.annotation.Configuration;
 public class MetricsConfiguration {
 
   /**
-   * A distribution summary for the accuracy of text based identity verification.
+   * A meter provider for the identity accuracy metrics.
    *
-   * @param registry The meter registry to use.
-   * @return The build distribution summary.
+   * @param registry The registry to use.
+   * @return The identity accuracy meter provider.
    */
   @Bean
-  DistributionSummary identityTextAccuracy(MeterRegistry registry) {
-    return DistributionSummary.builder("identity.accuracy.text")
-        .description("How closely matched the text of a given identity was to TIS data.")
+  MeterProvider<DistributionSummary> identityAccuracy(MeterRegistry registry) {
+    return DistributionSummary.builder("identity.accuracy")
+        .description("How closely matched a given identity's name was to TIS data.")
         .baseUnit(BaseUnits.PERCENT)
         .scale(100)
         .maximumExpectedValue(100.0)
-        .register(registry);
-  }
-
-  /**
-   * A distribution summary for the accuracy of phonetic based identity verification.
-   *
-   * @param registry The meter registry to use.
-   * @return The build distribution summary.
-   */
-  @Bean
-  DistributionSummary identityPhoneticAccuracy(MeterRegistry registry) {
-    return DistributionSummary.builder("identity.accuracy.phonetic")
-        .description("How closely matched the phonetics of a given identity was to TIS data.")
-        .baseUnit(BaseUnits.PERCENT)
-        .scale(100)
-        .maximumExpectedValue(100.0)
-        .register(registry);
+        .withRegistry(registry);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/MetricsService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/MetricsService.java
@@ -22,47 +22,95 @@
 package uk.nhs.hee.tis.trainee.credentials.service;
 
 import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Meter.MeterProvider;
 import org.springframework.stereotype.Service;
 
 /** A service for publishing custom application metrics. */
 @Service
 public class MetricsService {
 
+  private static final String TAG_ANALYSIS_TYPE = "AnalysisType";
+  private static final String ANALYSIS_TYPE_PHONETIC = "phonetic";
+  private static final String ANALYSIS_TYPE_TEXT = "text";
+
+  private static final String TAG_NAME_TYPE = "NameType";
+  private static final String NAME_TYPE_FORENAME = "forename";
+  private static final String NAME_TYPE_SURNAME = "surname";
+
   private static final String ACCURACY_ERROR_TEMPLATE =
       "%s accuracy out of bounds, must be between 0.0 and 1.0.";
 
-  private final DistributionSummary identityTextAccuracy;
-  private final DistributionSummary identityPhoneticAccuracy;
+  private final MeterProvider<DistributionSummary> identityAccuracy;
 
-  public MetricsService(
-      DistributionSummary identityTextAccuracy, DistributionSummary identityPhoneticAccuracy) {
-    this.identityTextAccuracy = identityTextAccuracy;
-    this.identityPhoneticAccuracy = identityPhoneticAccuracy;
+  public MetricsService(MeterProvider<DistributionSummary> identityAccuracy) {
+    this.identityAccuracy = identityAccuracy;
   }
 
   /**
-   * Publish an accuracy value for the text identity accuracy metric.
+   * Publish an accuracy value for the phonetic-based forename accuracy metric.
    *
    * @param accuracy The percentage accuracy between 0.0 and 1.0.
    */
-  public void publishIdentityTextAccuracy(double accuracy) {
+  public void publishForenamePhoneticAccuracy(double accuracy) {
     if (accuracy < 0.0 || accuracy > 1.0) {
-      throw new IllegalArgumentException(ACCURACY_ERROR_TEMPLATE.formatted("text"));
+      throw new IllegalArgumentException(ACCURACY_ERROR_TEMPLATE.formatted(ANALYSIS_TYPE_PHONETIC));
     }
 
-    identityTextAccuracy.record(accuracy);
+    identityAccuracy
+        .withTags(
+            TAG_ANALYSIS_TYPE, ANALYSIS_TYPE_PHONETIC,
+            TAG_NAME_TYPE, NAME_TYPE_FORENAME)
+        .record(accuracy);
   }
 
   /**
-   * Publish an accuracy value for the phonetic identity accuracy metric.
+   * Publish an accuracy value for the text-based forename accuracy metric.
    *
    * @param accuracy The percentage accuracy between 0.0 and 1.0.
    */
-  public void publishIdentityPhoneticAccuracy(double accuracy) {
+  public void publishForenameTextAccuracy(double accuracy) {
     if (accuracy < 0.0 || accuracy > 1.0) {
-      throw new IllegalArgumentException(ACCURACY_ERROR_TEMPLATE.formatted("Phonetic"));
+      throw new IllegalArgumentException(ACCURACY_ERROR_TEMPLATE.formatted(ANALYSIS_TYPE_TEXT));
     }
 
-    identityPhoneticAccuracy.record(accuracy);
+    identityAccuracy
+        .withTags(
+            TAG_ANALYSIS_TYPE, ANALYSIS_TYPE_TEXT,
+            TAG_NAME_TYPE, NAME_TYPE_FORENAME)
+        .record(accuracy);
+  }
+
+  /**
+   * Publish an accuracy value for the phonetic-based surname accuracy metric.
+   *
+   * @param accuracy The percentage accuracy between 0.0 and 1.0.
+   */
+  public void publishSurnamePhoneticAccuracy(double accuracy) {
+    if (accuracy < 0.0 || accuracy > 1.0) {
+      throw new IllegalArgumentException(ACCURACY_ERROR_TEMPLATE.formatted(ANALYSIS_TYPE_PHONETIC));
+    }
+
+    identityAccuracy
+        .withTags(
+            TAG_ANALYSIS_TYPE, ANALYSIS_TYPE_PHONETIC,
+            TAG_NAME_TYPE, NAME_TYPE_SURNAME)
+        .record(accuracy);
+  }
+
+  /**
+   * Publish an accuracy value for the text-based surname accuracy metric.
+   *
+   * @param accuracy The percentage accuracy between 0.0 and 1.0.
+   */
+  public void publishSurnameTextAccuracy(double accuracy) {
+    if (accuracy < 0.0 || accuracy > 1.0) {
+      throw new IllegalArgumentException(ACCURACY_ERROR_TEMPLATE.formatted(ANALYSIS_TYPE_TEXT));
+    }
+
+    identityAccuracy
+        .withTags(
+            TAG_ANALYSIS_TYPE, ANALYSIS_TYPE_TEXT,
+            TAG_NAME_TYPE, NAME_TYPE_SURNAME)
+        .record(accuracy);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/MetricsService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/MetricsService.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.service;
+
+import io.micrometer.core.instrument.DistributionSummary;
+import org.springframework.stereotype.Service;
+
+/** A service for publishing custom application metrics. */
+@Service
+public class MetricsService {
+
+  private static final String ACCURACY_ERROR_TEMPLATE =
+      "%s accuracy out of bounds, must be between 0.0 and 1.0.";
+
+  private final DistributionSummary identityTextAccuracy;
+  private final DistributionSummary identityPhoneticAccuracy;
+
+  public MetricsService(
+      DistributionSummary identityTextAccuracy, DistributionSummary identityPhoneticAccuracy) {
+    this.identityTextAccuracy = identityTextAccuracy;
+    this.identityPhoneticAccuracy = identityPhoneticAccuracy;
+  }
+
+  /**
+   * Publish an accuracy value for the text identity accuracy metric.
+   *
+   * @param accuracy The percentage accuracy between 0.0 and 1.0.
+   */
+  public void publishIdentityTextAccuracy(double accuracy) {
+    if (accuracy < 0.0 || accuracy > 1.0) {
+      throw new IllegalArgumentException(ACCURACY_ERROR_TEMPLATE.formatted("text"));
+    }
+
+    identityTextAccuracy.record(accuracy);
+  }
+
+  /**
+   * Publish an accuracy value for the phonetic identity accuracy metric.
+   *
+   * @param accuracy The percentage accuracy between 0.0 and 1.0.
+   */
+  public void publishIdentityPhoneticAccuracy(double accuracy) {
+    if (accuracy < 0.0 || accuracy > 1.0) {
+      throw new IllegalArgumentException(ACCURACY_ERROR_TEMPLATE.formatted("Phonetic"));
+    }
+
+    identityPhoneticAccuracy.record(accuracy);
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationService.java
@@ -29,10 +29,15 @@ import java.net.URI;
 import java.security.SecureRandom;
 import java.time.LocalDate;
 import java.util.Base64;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.codec.language.DoubleMetaphone;
+import org.apache.commons.text.similarity.LevenshteinDistance;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -41,9 +46,7 @@ import uk.nhs.hee.tis.trainee.credentials.config.GatewayProperties.VerificationP
 import uk.nhs.hee.tis.trainee.credentials.dto.IdentityDataDto;
 import uk.nhs.hee.tis.trainee.credentials.service.GatewayService.TokenResponse;
 
-/**
- * A service providing credential verification functionality.
- */
+/** A service providing credential verification functionality. */
 @Slf4j
 @Service
 @XRayEnabled
@@ -69,34 +72,43 @@ public class VerificationService {
   private final JwtService jwtService;
   private final CachingDelegate cachingDelegate;
   private final VerificationProperties properties;
+  private final MetricsService metricsService;
+
+  private final LevenshteinDistance levenshteinDistance = LevenshteinDistance.getDefaultInstance();
+  private final DoubleMetaphone metaphone = new DoubleMetaphone();
 
   /**
    * Create a service providing credential verification functionality.
    *
-   * @param gatewayService  The service to handle all credential gateway interactions.
-   * @param jwtService      The JWT service to use.
+   * @param gatewayService The service to handle all credential gateway interactions.
+   * @param jwtService The JWT service to use.
    * @param cachingDelegate The caching delegate for caching data between requests.
-   * @param properties      The application's gateway verification configuration.
+   * @param properties The application's gateway verification configuration.
    */
-  VerificationService(GatewayService gatewayService, JwtService jwtService,
-      CachingDelegate cachingDelegate, VerificationProperties properties) {
+  VerificationService(
+      GatewayService gatewayService,
+      JwtService jwtService,
+      CachingDelegate cachingDelegate,
+      VerificationProperties properties,
+      MetricsService metricsService) {
     this.gatewayService = gatewayService;
     this.jwtService = jwtService;
     this.cachingDelegate = cachingDelegate;
     this.properties = properties;
+    this.metricsService = metricsService;
   }
 
   /**
    * Start the identity credential verification process, the result will direct the user to provide
    * an identity credential using the credential gateway.
    *
-   * @param authToken   The request's authorization token.
-   * @param dto         The user's identity data.
+   * @param authToken The request's authorization token.
+   * @param dto The user's identity data.
    * @param clientState The state sent by client when making the request to start verification.
    * @return A URI to a credential gateway prompt for an identity credential.
    */
-  public URI startIdentityVerification(String authToken, IdentityDataDto dto,
-      @Nullable String clientState) {
+  public URI startIdentityVerification(
+      String authToken, IdentityDataDto dto, @Nullable String clientState) {
     // Cache the provided identity data against the nonce.
     UUID nonce = UUID.randomUUID();
     cachingDelegate.cacheIdentityData(nonce, dto);
@@ -152,14 +164,14 @@ public class VerificationService {
   /**
    * Complete the credential verification process.
    *
-   * @param code             The code provided by the credential gateway.
-   * @param state            The state set in the initial gateway request.
-   * @param error            The error code from the verification callback.
+   * @param code The code provided by the credential gateway.
+   * @param state The state set in the initial gateway request.
+   * @param error The error code from the verification callback.
    * @param errorDescription The error description from the verification callback.
    * @return The built redirect URI for completed verification.
    */
-  public URI completeCredentialVerification(String code, String state, @Nullable String error,
-      @Nullable String errorDescription) {
+  public URI completeCredentialVerification(
+      String code, String state, @Nullable String error, @Nullable String errorDescription) {
     // If successfully verified then continue, else return callback error.
     if (error == null) {
       return completeCredentialVerification(code, state);
@@ -181,7 +193,7 @@ public class VerificationService {
   /**
    * Complete the credential verification process.
    *
-   * @param code  The code provided by the credential gateway.
+   * @param code The code provided by the credential gateway.
    * @param state The state set in the initial gateway request.
    * @return The built redirect URI for completed verification.
    */
@@ -195,9 +207,9 @@ public class VerificationService {
     } else {
       URI tokenEndpoint = URI.create(properties.tokenEndpoint());
       URI redirectEndpoint = URI.create(properties.redirectUri());
-      ResponseEntity<TokenResponse> tokenResponseEntity
-          = gatewayService.getTokenResponse(tokenEndpoint, redirectEndpoint, code,
-          codeVerifier.get());
+      ResponseEntity<TokenResponse> tokenResponseEntity =
+          gatewayService.getTokenResponse(
+              tokenEndpoint, redirectEndpoint, code, codeVerifier.get());
       Claims claims = gatewayService.getTokenClaims(tokenResponseEntity);
       String scope = gatewayService.getTokenScope(tokenResponseEntity);
       String credentialType = scope.replace(CREDENTIAL_PREFIX, "");
@@ -216,8 +228,9 @@ public class VerificationService {
     if (failureCode == null) {
       uriBuilder = UriComponentsBuilder.fromUriString("/credential-verified");
     } else {
-      uriBuilder = UriComponentsBuilder.fromUriString("/invalid-credential")
-          .queryParam(PARAM_REASON, failureCode);
+      uriBuilder =
+          UriComponentsBuilder.fromUriString("/invalid-credential")
+              .queryParam(PARAM_REASON, failureCode);
     }
 
     Optional<String> clientState = cachingDelegate.getClientState(stateUuid);
@@ -243,21 +256,88 @@ public class VerificationService {
       LocalDate claimBirthDate = LocalDate.parse(claims.get(CLAIM_BIRTH_DATE, String.class));
       String identityId = claims.get(CLAIM_UNIQUE_IDENTIFIER, String.class);
 
-      if (identityData.forenames().equalsIgnoreCase(claimFirstName) && identityData.surname()
-          .equalsIgnoreCase(claimFamilyName) && identityData.dateOfBirth().equals(claimBirthDate)
+      boolean firstNameValid = verifyName(identityData.forenames(), claimFirstName);
+      boolean familyNameValid = verifyName(identityData.surname(), claimFamilyName);
+
+      if (firstNameValid
+          && familyNameValid
+          && identityData.dateOfBirth().equals(claimBirthDate)
           && identityId != null) {
         Optional<String> sessionIdentifier = cachingDelegate.getUnverifiedSessionIdentifier(nonce);
 
         // If the unverified session is cached, move it to the verified session cache.
         if (sessionIdentifier.isPresent()) {
-          cachingDelegate.cacheVerifiedIdentityIdentifier(sessionIdentifier.get(),
-              UUID.fromString(identityId));
+          cachingDelegate.cacheVerifiedIdentityIdentifier(
+              sessionIdentifier.get(), UUID.fromString(identityId));
           return true;
         }
       }
     }
 
     return false;
+  }
+
+  /**
+   * Verify the givens names are similar enough to be considered equal.
+   *
+   * @param identityName The TIS sourced identity name data.
+   * @param claimName The credential sourced identity name data.
+   * @return true if considered equal, else false.
+   */
+  private boolean verifyName(String identityName, String claimName) {
+    LinkedHashSet<String> claimNames = new LinkedHashSet<>();
+    claimNames.add(claimName);
+    claimNames.addAll(List.of(claimName.split("[- ]")));
+
+    NameVerificationResult result =
+        claimNames.stream()
+            .map(
+                name ->
+                    new NameVerificationResult(
+                        name,
+                        calculatePhoneticAccuracy(identityName, name),
+                        calculateTextAccuracy(identityName, name)))
+            .max(
+                Comparator.comparingDouble(NameVerificationResult::phoneticAccuracy)
+                    .thenComparingDouble(NameVerificationResult::textAccuracy))
+            .orElseThrow();
+
+    metricsService.publishIdentityPhoneticAccuracy(result.phoneticAccuracy);
+    metricsService.publishIdentityTextAccuracy(result.textAccuracy);
+
+    // Require 50% text accuracy if the name is a phonetic match, otherwise require 80%.
+    double requiredTextAccuracy = result.phoneticAccuracy() == 1.0 ? 0.5 : 0.8;
+    return result.textAccuracy() >= requiredTextAccuracy;
+  }
+
+  /**
+   * Calculate the text-based accuracy of an identity's name.
+   *
+   * @param identityName The TIS sourced identity name data.
+   * @param claimName The credential sourced identity name data.
+   * @return The percentage accuracy between 0.0 and 1.0.
+   */
+  private double calculateTextAccuracy(String identityName, String claimName) {
+    double textDistance =
+        levenshteinDistance.apply(identityName.toLowerCase(), claimName.toLowerCase());
+    double textLength = Math.max(identityName.length(), claimName.length());
+    return 1 - (textDistance / textLength);
+  }
+
+  /**
+   * Calculate the phonetic-based accuracy of an identity's name.
+   *
+   * @param identityName The TIS sourced identity name data.
+   * @param claimName The credential sourced identity name data.
+   * @return The percentage accuracy between 0.0 and 1.0.
+   */
+  private double calculatePhoneticAccuracy(String identityName, String claimName) {
+    String identityCode = metaphone.doubleMetaphone(identityName);
+    String claimCode = metaphone.doubleMetaphone(claimName);
+    double phoneticDistance =
+        LevenshteinDistance.getDefaultInstance().apply(identityCode, claimCode);
+    double phoneticLength = Math.max(identityCode.length(), claimCode.length());
+    return 1 - (phoneticDistance / phoneticLength);
   }
 
   /**
@@ -274,4 +354,14 @@ public class VerificationService {
 
     return verifiedIdentityId.isPresent();
   }
+
+  /**
+   * A result of verifying the similarity of names.
+   *
+   * @param name The identity that was checked against.
+   * @param phoneticAccuracy The phonetic accuracy of the name.
+   * @param textAccuracy The text accuracy of the name.
+   */
+  private record NameVerificationResult(
+      String name, double phoneticAccuracy, double textAccuracy) {}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,7 +58,7 @@ management:
   metrics:
     enable:
       all: false
-      identity.accuracy: true
+      identity.inaccuracy: true
     tags:
       Environment: ${application.environment}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,6 +50,18 @@ com:
       emitters:
         daemon-address: ${AWS_XRAY_DAEMON_ADDRESS:}
 
+management:
+  cloudwatch:
+    metrics:
+      export:
+        namespace: TIS/Trainee/Credentials
+  metrics:
+    enable:
+      all: false
+      identity.accuracy: true
+    tags:
+      environment: ${application.environment}
+
 sentry:
   dsn: ${SENTRY_DSN:}
   environment: ${application.environment}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,7 +60,7 @@ management:
       all: false
       identity.accuracy: true
     tags:
-      environment: ${application.environment}
+      Environment: ${application.environment}
 
 sentry:
   dsn: ${SENTRY_DSN:}

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/config/MetricsConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/config/MetricsConfigurationTest.java
@@ -43,17 +43,17 @@ class MetricsConfigurationTest {
   }
 
   @Test
-  void shouldConfigureIdentityAccuracy() {
+  void shouldConfigureIdentityInaccuracy() {
     MeterRegistry registry = new SimpleMeterRegistry();
 
-    MeterProvider<DistributionSummary> provider = configuration.identityAccuracy(registry);
+    MeterProvider<DistributionSummary> provider = configuration.identityInaccuracy(registry);
 
-    DistributionSummary identityAccuracy = provider.withTags();
-    Meter.Id id = identityAccuracy.getId();
-    assertThat("Unexpected meter name.", id.getName(), is("identity.accuracy"));
+    DistributionSummary identityInaccuracy = provider.withTags();
+    Meter.Id id = identityInaccuracy.getId();
+    assertThat("Unexpected meter name.", id.getName(), is("identity.inaccuracy"));
     assertThat("Unexpected base unit.", id.getBaseUnit(), is(PERCENT));
 
-    identityAccuracy.record(0.5);
-    assertThat("Unexpected meter scaling.", identityAccuracy.totalAmount(), is(50.0));
+    identityInaccuracy.record(0.5);
+    assertThat("Unexpected meter scaling.", identityInaccuracy.totalAmount(), is(50.0));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/config/MetricsConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/config/MetricsConfigurationTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Meter.MeterProvider;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,24 +43,17 @@ class MetricsConfigurationTest {
   }
 
   @Test
-  void shouldConfigureIdentityTextAccuracy() {
+  void shouldConfigureIdentityAccuracy() {
     MeterRegistry registry = new SimpleMeterRegistry();
 
-    DistributionSummary distributionSummary = configuration.identityTextAccuracy(registry);
+    MeterProvider<DistributionSummary> provider = configuration.identityAccuracy(registry);
 
-    Meter.Id id = distributionSummary.getId();
-    assertThat("Unexpected meter name.", id.getName(), is("identity.accuracy.text"));
+    DistributionSummary identityAccuracy = provider.withTags();
+    Meter.Id id = identityAccuracy.getId();
+    assertThat("Unexpected meter name.", id.getName(), is("identity.accuracy"));
     assertThat("Unexpected base unit.", id.getBaseUnit(), is(PERCENT));
-  }
 
-  @Test
-  void shouldConfigureIdentityPhoneticAccuracy() {
-    MeterRegistry registry = new SimpleMeterRegistry();
-
-    DistributionSummary distributionSummary = configuration.identityPhoneticAccuracy(registry);
-
-    Meter.Id id = distributionSummary.getId();
-    assertThat("Unexpected meter name.", id.getName(), is("identity.accuracy.phonetic"));
-    assertThat("Unexpected base unit.", id.getBaseUnit(), is(PERCENT));
+    identityAccuracy.record(0.5);
+    assertThat("Unexpected meter scaling.", identityAccuracy.totalAmount(), is(50.0));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/config/MetricsConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/config/MetricsConfigurationTest.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.config;
+
+import static io.micrometer.core.instrument.binder.BaseUnits.PERCENT;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MetricsConfigurationTest {
+
+  private MetricsConfiguration configuration;
+
+  @BeforeEach
+  void setUp() {
+    configuration = new MetricsConfiguration();
+  }
+
+  @Test
+  void shouldConfigureIdentityTextAccuracy() {
+    MeterRegistry registry = new SimpleMeterRegistry();
+
+    DistributionSummary distributionSummary = configuration.identityTextAccuracy(registry);
+
+    Meter.Id id = distributionSummary.getId();
+    assertThat("Unexpected meter name.", id.getName(), is("identity.accuracy.text"));
+    assertThat("Unexpected base unit.", id.getBaseUnit(), is(PERCENT));
+  }
+
+  @Test
+  void shouldConfigureIdentityPhoneticAccuracy() {
+    MeterRegistry registry = new SimpleMeterRegistry();
+
+    DistributionSummary distributionSummary = configuration.identityPhoneticAccuracy(registry);
+
+    Meter.Id id = distributionSummary.getId();
+    assertThat("Unexpected meter name.", id.getName(), is("identity.accuracy.phonetic"));
+    assertThat("Unexpected base unit.", id.getBaseUnit(), is(PERCENT));
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/MetricsServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/MetricsServiceTest.java
@@ -37,6 +37,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class MetricsServiceTest {
@@ -77,11 +78,20 @@ class MetricsServiceTest {
   }
 
   @ParameterizedTest
-  @ValueSource(doubles = {0.0, 0.5, 1.0})
-  void shouldPublishForenameTextAccuracyWhenValid(double accuracy) {
+  @CsvSource(
+      delimiter = '|',
+      textBlock =
+          """
+          0.0  | 1.0
+          0.25 | 0.75
+          0.5  | 0.5
+          0.75 | 0.25
+          1.0  | 0.0
+          """)
+  void shouldPublishForenameTextAccuracyWhenValid(double accuracy, double inaccuracy) {
     service.publishForenameTextAccuracy(accuracy);
 
-    verify(identityAccuracy).record(accuracy);
+    verify(identityAccuracy).record(inaccuracy);
 
     String analysisType = identityAccuracy.getId().getTag("AnalysisType");
     assertThat("Unexpected AnalysisType.", analysisType, is("text"));
@@ -100,11 +110,20 @@ class MetricsServiceTest {
   }
 
   @ParameterizedTest
-  @ValueSource(doubles = {0.0, 0.5, 1.0})
-  void shouldPublishForenamePhoneticAccuracyWhenValid(double accuracy) {
+  @CsvSource(
+      delimiter = '|',
+      textBlock =
+          """
+          0.0  | 1.0
+          0.25 | 0.75
+          0.5  | 0.5
+          0.75 | 0.25
+          1.0  | 0.0
+         """)
+  void shouldPublishForenamePhoneticAccuracyWhenValid(double accuracy, double inaccuracy) {
     service.publishForenamePhoneticAccuracy(accuracy);
 
-    verify(identityAccuracy).record(accuracy);
+    verify(identityAccuracy).record(inaccuracy);
 
     String analysisType = identityAccuracy.getId().getTag("AnalysisType");
     assertThat("Unexpected AnalysisType.", analysisType, is("phonetic"));
@@ -123,11 +142,20 @@ class MetricsServiceTest {
   }
 
   @ParameterizedTest
-  @ValueSource(doubles = {0.0, 0.5, 1.0})
-  void shouldPublishSurnameTextAccuracyWhenValid(double accuracy) {
+  @CsvSource(
+      delimiter = '|',
+      textBlock =
+          """
+          0.0  | 1.0
+          0.25 | 0.75
+          0.5  | 0.5
+          0.75 | 0.25
+          1.0  | 0.0
+          """)
+  void shouldPublishSurnameTextAccuracyWhenValid(double accuracy, double inaccuracy) {
     service.publishSurnameTextAccuracy(accuracy);
 
-    verify(identityAccuracy).record(accuracy);
+    verify(identityAccuracy).record(inaccuracy);
 
     String analysisType = identityAccuracy.getId().getTag("AnalysisType");
     assertThat("Unexpected AnalysisType.", analysisType, is("text"));
@@ -146,11 +174,20 @@ class MetricsServiceTest {
   }
 
   @ParameterizedTest
-  @ValueSource(doubles = {0.0, 0.5, 1.0})
-  void shouldPublishSurnamePhoneticAccuracyWhenValid(double accuracy) {
+  @CsvSource(
+      delimiter = '|',
+      textBlock =
+          """
+          0.0  | 1.0
+          0.25 | 0.75
+          0.5  | 0.5
+          0.75 | 0.25
+          1.0  | 0.0
+          """)
+  void shouldPublishSurnamePhoneticAccuracyWhenValid(double accuracy, double inaccuracy) {
     service.publishSurnamePhoneticAccuracy(accuracy);
 
-    verify(identityAccuracy).record(accuracy);
+    verify(identityAccuracy).record(inaccuracy);
 
     String analysisType = identityAccuracy.getId().getTag("AnalysisType");
     assertThat("Unexpected AnalysisType.", analysisType, is("phonetic"));

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/MetricsServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/MetricsServiceTest.java
@@ -1,0 +1,80 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.credentials.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.micrometer.core.instrument.DistributionSummary;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class MetricsServiceTest {
+
+  private MetricsService service;
+  private DistributionSummary textAccuracy;
+  private DistributionSummary phoneticAccuracy;
+
+  @BeforeEach
+  void setUp() {
+    textAccuracy = mock(DistributionSummary.class);
+    phoneticAccuracy = mock(DistributionSummary.class);
+    service = new MetricsService(textAccuracy, phoneticAccuracy);
+  }
+
+  @ParameterizedTest
+  @ValueSource(doubles = {-0.1, 1.1})
+  void shouldNotPublishIdentityTextAccuracyWhenInvalid(double accuracy) {
+    assertThrows(
+        IllegalArgumentException.class, () -> service.publishIdentityTextAccuracy(accuracy));
+
+    verifyNoInteractions(textAccuracy);
+  }
+
+  @ParameterizedTest
+  @ValueSource(doubles = {0.0, 0.5, 1.0})
+  void shouldPublishIdentityTextAccuracyWhenValid(double accuracy) {
+    service.publishIdentityTextAccuracy(accuracy);
+
+    verify(textAccuracy).record(accuracy);
+  }
+
+  @ParameterizedTest
+  @ValueSource(doubles = {-0.1, 1.1})
+  void shouldNotPublishIdentityPhoneticAccuracyWhenInvalid(double accuracy) {
+    assertThrows(
+        IllegalArgumentException.class, () -> service.publishIdentityPhoneticAccuracy(accuracy));
+
+    verifyNoInteractions(textAccuracy);
+  }
+
+  @ParameterizedTest
+  @ValueSource(doubles = {0.0, 0.5, 1.0})
+  void shouldPublishIdentityPhoneticAccuracyWhenValid(double accuracy) {
+    service.publishIdentityPhoneticAccuracy(accuracy);
+
+    verify(phoneticAccuracy).record(accuracy);
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/credentials/service/VerificationServiceTest.java
@@ -53,8 +53,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InOrder;
-import org.mockito.Mockito;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -597,11 +595,10 @@ class VerificationServiceTest {
     verificationService.completeCredentialVerification(CODE, state.toString(), null, null);
 
     ArgumentCaptor<Double> accuracyCaptor = ArgumentCaptor.captor();
-    InOrder metricsInOrder = Mockito.inOrder(metricsService);
-    metricsInOrder.verify(metricsService).publishIdentityPhoneticAccuracy(accuracyCaptor.capture());
-    metricsInOrder.verify(metricsService).publishIdentityTextAccuracy(accuracyCaptor.capture());
-    metricsInOrder.verify(metricsService).publishIdentityPhoneticAccuracy(1.0);
-    metricsInOrder.verify(metricsService).publishIdentityTextAccuracy(1.0);
+    verify(metricsService).publishForenamePhoneticAccuracy(accuracyCaptor.capture());
+    verify(metricsService).publishForenameTextAccuracy(accuracyCaptor.capture());
+    verify(metricsService).publishSurnamePhoneticAccuracy(1.0);
+    verify(metricsService).publishSurnameTextAccuracy(1.0);
 
     List<Double> accuracies = accuracyCaptor.getAllValues();
     DecimalFormat decimalFormat = new DecimalFormat("#.##");
@@ -656,11 +653,10 @@ class VerificationServiceTest {
     verificationService.completeCredentialVerification(CODE, state.toString(), null, null);
 
     ArgumentCaptor<Double> accuracyCaptor = ArgumentCaptor.captor();
-    InOrder metricsInOrder = Mockito.inOrder(metricsService);
-    metricsInOrder.verify(metricsService).publishIdentityPhoneticAccuracy(1.0);
-    metricsInOrder.verify(metricsService).publishIdentityTextAccuracy(1.0);
-    metricsInOrder.verify(metricsService).publishIdentityPhoneticAccuracy(accuracyCaptor.capture());
-    metricsInOrder.verify(metricsService).publishIdentityTextAccuracy(accuracyCaptor.capture());
+    verify(metricsService).publishForenamePhoneticAccuracy(1.0);
+    verify(metricsService).publishForenameTextAccuracy(1.0);
+    verify(metricsService).publishSurnamePhoneticAccuracy(accuracyCaptor.capture());
+    verify(metricsService).publishSurnameTextAccuracy(accuracyCaptor.capture());
 
     List<Double> accuracies = accuracyCaptor.getAllValues();
     DecimalFormat decimalFormat = new DecimalFormat("#.##");


### PR DESCRIPTION
The identity checks rely on matching the forename and surname between TIS and the provided DSP credential. As there is a high percentage chance that names will mismatch between spelling mistakes and inclusive/exclusion of middle name, the name checking needs to be more forgiving.

Update the VerificationService to check the phonetic and text accuracies and make a decision based on the similarity rather than exact matching. Split names on spaces and hypens to allow matching when middle names, or double barrelled names are used.

Publish metrics for both phonetic and text accuracy to Cloudwatch to allow monitoring and ongoing improvements to be made to the level of fuzziness allowed.

TIS21-6065